### PR TITLE
Cdip 1 0 3 a

### DIFF
--- a/app/transform_service/smartconnect_transformers.py
+++ b/app/transform_service/smartconnect_transformers.py
@@ -44,8 +44,8 @@ class AttributeMapper(BaseModel):
     event_types: Optional[List[str]]
 
 class TransformationRules(BaseModel):
-    category_map: List[CategoryPair]
-    attribute_map: List[AttributeMapper]
+    category_map: Optional[List[CategoryPair]] = []
+    attribute_map: Optional[List[AttributeMapper]] = []
 
 class SmartConnectConfigurationAdditional(BaseModel):
     ca_uuid: uuid.UUID
@@ -91,7 +91,7 @@ class SmartEREventTransformer:
             
         self.ca_timezone = guess_ca_timezone(self.ca) if self.ca else self._default_timezone
 
-        transformation_rules_dict = self._config.additional.get('transformation_rules', None)
+        transformation_rules_dict = self._config.additional.get('transformation_rules', {})
         if transformation_rules_dict:
             self._transformation_rules = TransformationRules.parse_obj(transformation_rules_dict)
 
@@ -280,9 +280,3 @@ class SmartEREventTransformer:
         incident = IndependentIncident.parse_obj(incident_data)
 
         return incident
-
-
-
-
-
-


### PR DESCRIPTION
These changes cover a couple things:
* Work around an issue whereby we're not able to download a list of Conservation Areas (presumably for permissions reason). _The purpose for downloading the CAs was to find their boundary polygons and use them to guess the timezone. In some cases we're not able to download this data and so we predict timezone based on individual Observations._
* Add some logging to help as we pilot this SMART Connect integration.