### PR TITLE
Dead Letter logging fix and metrics

### DIFF
--- a/app/subscribers/kafka_subscriber.py
+++ b/app/subscribers/kafka_subscriber.py
@@ -263,13 +263,13 @@ async def process_failed_transformed_observation(key, transformed_message):
         )
         retry_topic: faust.Topic = topics_dict.get(retry_topic_str)
         extra_dict = {
-                ExtraKeys.DeviceId: device_id,
-                ExtraKeys.InboundIntId: integration_id,
-                ExtraKeys.OutboundIntId: outbound_config_id,
-                ExtraKeys.StreamType: observation_type,
-                ExtraKeys.RetryTopic: retry_topic_str,
-                ExtraKeys.RetryAttempt: retry_attempt,
-            }
+            ExtraKeys.DeviceId: device_id,
+            ExtraKeys.InboundIntId: integration_id,
+            ExtraKeys.OutboundIntId: outbound_config_id,
+            ExtraKeys.StreamType: observation_type,
+            ExtraKeys.RetryTopic: retry_topic_str,
+            ExtraKeys.RetryAttempt: retry_attempt,
+        }
         if retry_topic_str != TopicEnum.observations_transformed_deadletter:
             logger.info(
                 "Putting failed transformed observation back on queue",
@@ -281,15 +281,15 @@ async def process_failed_transformed_observation(key, transformed_message):
                 extra={
                     **extra_dict,
                     ExtraKeys.AttentionNeeded: True,
-                    ExtraKeys.DeadLetter: True
-                })
+                    ExtraKeys.DeadLetter: True,
+                },
+            )
         await retry_topic.send(value=retry_transformed_message)
     except Exception as e:
-        logger.exception("Unexpected Error occurred while preparing failed transformed observation for reprocessing",
-                         extra={
-                             ExtraKeys.AttentionNeeded: True,
-                             ExtraKeys.DeadLetter: True
-                         })
+        logger.exception(
+            "Unexpected Error occurred while preparing failed transformed observation for reprocessing",
+            extra={ExtraKeys.AttentionNeeded: True, ExtraKeys.DeadLetter: True},
+        )
         # When all else fails post to dead letter
         await observations_transformed_deadletter.send(value=transformed_message)
 
@@ -306,12 +306,12 @@ async def process_failed_unprocessed_observation(key, message):
         retry_unprocessed_message = create_retry_message(raw_observation, attributes)
         retry_topic: faust.Topic = topics_dict.get(retry_topic_str)
         extra_dict = {
-                    ExtraKeys.DeviceId: device_id,
-                    ExtraKeys.InboundIntId: integration_id,
-                    ExtraKeys.StreamType: observation_type,
-                    ExtraKeys.RetryTopic: retry_topic_str,
-                    ExtraKeys.RetryAttempt: retry_attempt,
-                }
+            ExtraKeys.DeviceId: device_id,
+            ExtraKeys.InboundIntId: integration_id,
+            ExtraKeys.StreamType: observation_type,
+            ExtraKeys.RetryTopic: retry_topic_str,
+            ExtraKeys.RetryAttempt: retry_attempt,
+        }
         if retry_topic_str != TopicEnum.observations_transformed_deadletter:
             logger.info(
                 "Putting failed unprocessed observation back on queue",
@@ -323,16 +323,16 @@ async def process_failed_unprocessed_observation(key, message):
                 extra={
                     **extra_dict,
                     ExtraKeys.AttentionNeeded: True,
-                    ExtraKeys.DeadLetter: True
-                })
+                    ExtraKeys.DeadLetter: True,
+                },
+            )
         await retry_topic.send(value=retry_unprocessed_message)
     except Exception as e:
         # When all else fails post to dead letter
-        logger.exception("Unexpected Error occurred while preparing failed unprocessed observation for reprocessing",
-                         extra={
-                             ExtraKeys.AttentionNeeded: True,
-                             ExtraKeys.DeadLetter: True
-                         })
+        logger.exception(
+            "Unexpected Error occurred while preparing failed unprocessed observation for reprocessing",
+            extra={ExtraKeys.AttentionNeeded: True, ExtraKeys.DeadLetter: True},
+        )
         await observations_unprocessed_deadletter.send(value=message)
 
 
@@ -345,11 +345,10 @@ async def process_transformed_retry_observation(key, transformed_message):
         await wait_until_retry_at(retry_at)
         await process_transformed_observation(key, transformed_message)
     except Exception as e:
-        logger.exception("Unexpected Error occurred while attempting to process failed transformed observation",
-                         extra={
-                             ExtraKeys.AttentionNeeded: True,
-                             ExtraKeys.DeadLetter: True
-                         })
+        logger.exception(
+            "Unexpected Error occurred while attempting to process failed transformed observation",
+            extra={ExtraKeys.AttentionNeeded: True, ExtraKeys.DeadLetter: True},
+        )
         # When all else fails post to dead letter
         await observations_transformed_deadletter.send(value=transformed_message)
 
@@ -361,11 +360,10 @@ async def process_retry_observation(key, message):
         await wait_until_retry_at(retry_at)
         await process_observation(key, message)
     except Exception as e:
-        logger.exception("Unexpected Error occurred while attempting to process failed unprocessed observation",
-                         extra={
-                             ExtraKeys.AttentionNeeded: True,
-                             ExtraKeys.DeadLetter: True
-                         })
+        logger.exception(
+            "Unexpected Error occurred while attempting to process failed unprocessed observation",
+            extra={ExtraKeys.AttentionNeeded: True, ExtraKeys.DeadLetter: True},
+        )
         # When all else fails post to dead letter
         await observations_unprocessed_deadletter.send(value=message)
 
@@ -376,11 +374,10 @@ async def process_observations(streaming_data):
         try:
             await process_observation(key, message)
         except Exception as e:
-            logger.exception(f"Unexpected error prior to processing observation",
-                             extra={
-                                 ExtraKeys.AttentionNeeded: True,
-                                 ExtraKeys.DeadLetter: True
-                             })
+            logger.exception(
+                f"Unexpected error prior to processing observation",
+                extra={ExtraKeys.AttentionNeeded: True, ExtraKeys.DeadLetter: True},
+            )
             # When all else fails post to dead letter
             await observations_unprocessed_deadletter.send(value=message)
 
@@ -403,11 +400,10 @@ async def process_transformed_observations(streaming_transformed_data):
         try:
             await process_transformed_observation(key, transformed_message)
         except Exception as e:
-            logger.exception(f"Unexpected error prior to processing transformed observation",
-                             extra={
-                                 ExtraKeys.AttentionNeeded: True,
-                                 ExtraKeys.DeadLetter: True
-                             })
+            logger.exception(
+                f"Unexpected error prior to processing transformed observation",
+                extra={ExtraKeys.AttentionNeeded: True, ExtraKeys.DeadLetter: True},
+            )
             # When all else fails post to dead letter
             await observations_transformed_deadletter.send(value=transformed_message)
 
@@ -428,11 +424,11 @@ async def process_transformed_retry_long_observations(streaming_transformed_data
 async def log_metrics(app):
     m = app.monitor
     metrics_dict = {
-        'messages_received_by_topic': m.messages_received_by_topic,
-        'messages_sent_by_topic': m.messages_sent_by_topic,
-        'messages_active': m.messages_active,
-        'assignment_latency': m.assignment_latency,
-        'send_errors': m.send_errors,
+        "messages_received_by_topic": m.messages_received_by_topic,
+        "messages_sent_by_topic": m.messages_sent_by_topic,
+        "messages_active": m.messages_active,
+        "assignment_latency": m.assignment_latency,
+        "send_errors": m.send_errors,
         "rebalances": m.rebalances,
         "rebalance_return_avg": m.rebalance_return_avg,
     }

--- a/app/subscribers/services.py
+++ b/app/subscribers/services.py
@@ -51,7 +51,11 @@ def get_outbound_config_detail(outbound_id: UUID) -> schemas.OutboundConfigurati
         config = schemas.OutboundConfiguration.parse_raw(cached)
         logger.debug(
             "Using cached outbound integration detail",
-            extra={**extra_dict, ExtraKeys.AttentionNeeded: False, "outbound_detail": config},
+            extra={
+                **extra_dict,
+                ExtraKeys.AttentionNeeded: False,
+                "outbound_detail": config,
+            },
         )
         return config
 
@@ -70,10 +74,11 @@ def get_outbound_config_detail(outbound_id: UUID) -> schemas.OutboundConfigurati
             timeout=DEFAULT_TIMEOUT,
         )
     except ReadTimeoutError:
-        logger.error("Read Timeout", extra={**extra_dict, ExtraKeys.Url: outbound_integrations_endpoint})
-        raise ReferenceDataError(
-            f"Read Timeout for {outbound_integrations_endpoint}"
+        logger.error(
+            "Read Timeout",
+            extra={**extra_dict, ExtraKeys.Url: outbound_integrations_endpoint},
         )
+        raise ReferenceDataError(f"Read Timeout for {outbound_integrations_endpoint}")
     if response.status_code == 200:
         try:
             resp_json = response.json()
@@ -82,7 +87,9 @@ def get_outbound_config_detail(outbound_id: UUID) -> schemas.OutboundConfigurati
                 f"Failed decoding response for Outbound Integration Detail",
                 extra={**extra_dict, "resp_text": response.text},
             )
-            raise ReferenceDataError("Failed decoding response for Outbound Integration Detail")
+            raise ReferenceDataError(
+                "Failed decoding response for Outbound Integration Detail"
+            )
         else:
             config = schemas.OutboundConfiguration.parse_obj(resp_json)
             if config:  # don't cache empty response
@@ -143,10 +150,11 @@ def get_inbound_integration_detail(
             timeout=DEFAULT_TIMEOUT,
         )
     except ReadTimeoutError:
-        logger.error("Read Timeout", extra={**extra_dict, ExtraKeys.Url: inbound_integrations_endpoint})
-        raise ReferenceDataError(
-            f"Read Timeout for {inbound_integrations_endpoint}"
+        logger.error(
+            "Read Timeout",
+            extra={**extra_dict, ExtraKeys.Url: inbound_integrations_endpoint},
         )
+        raise ReferenceDataError(f"Read Timeout for {inbound_integrations_endpoint}")
 
     if response.status_code == 200:
         try:
@@ -156,7 +164,9 @@ def get_inbound_integration_detail(
                 f"Failed decoding response for InboundIntegration Detail",
                 extra={**extra_dict, "resp_text": response.text},
             )
-            raise ReferenceDataError("Failed decoding response for InboundIntegration Detail")
+            raise ReferenceDataError(
+                "Failed decoding response for InboundIntegration Detail"
+            )
         else:
             config = schemas.IntegrationInformation.parse_obj(resp_json)
             if config:  # don't cache empty response

--- a/app/transform_service/dispatchers.py
+++ b/app/transform_service/dispatchers.py
@@ -124,7 +124,7 @@ class SmartConnectDispatcher:
             api=self.config.endpoint,
             username=self.config.login,
             password=self.config.password,
-            version=self.config.additional.get("version")
+            version=self.config.additional.get("version"),
         )
         for patrol_request in item.patrol_requests:
             smartclient.post_smart_request(


### PR DESCRIPTION
fixing logging so that when retries are exhausted and observation is sent to dead letter we log the json payload field that will trigger the alert

added some monitoring metrics to the heartbeat that should help us better troubleshoot the consumer lag issue