### PR TITLE
Fix docker image repos

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,8 +17,7 @@ commands:
       - run: 'gcloud auth activate-service-account --key-file=<(echo "$ENCODED_GCR_KEY" | base64 --decode)'
   docker_login:
     steps:
-      - run: 'echo "$ENCODED_GCR_KEY" | base64 --decode | docker login --username _json_key --password-stdin https://gcr.io'
-
+      - run: 'echo "$ENCODED_GCR_KEY" | base64 --decode | docker login --username _json_key --password-stdin https://us-central1-docker.pkg.dev'
   trigger_downstream_builds:
     parameters:
       target_project_slug:
@@ -137,15 +136,15 @@ workflows:
       - build_cdip_routing_image:
           requires:
           - check_code
-      - build:
-          requires:
-          - check_code
-      - push:
-          requires:
-          - build
-          filters:
-            branches:
-              only: main
+      # - build:
+      #     requires:
+      #     - check_code
+      # - push:
+      #     requires:
+      #     - build
+      #     filters:
+      #       branches:
+      #         only: main
   release_workflow:
     jobs:
       - build:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -12,7 +12,7 @@ SHELL := /bin/sh
 
 .DEFAULT_GOAL := help
 
-gcr_root := gcr.io/cdip-78ca/cdip-routing
+gcr_root := us-central1-docker.pkg.dev/cdip-78ca/gundi/cdip-routing
 semver_file := $(CURDIR)/VERSION
 
 .PHONY: help
@@ -22,20 +22,8 @@ help: ## show this help
 	@ grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk -F ":.*?## " '{printf "\033[36m%-20s\033[0m%s\033[0m\n", $$1, $$2}' >&2
 
 .PHONY: build_and_push
-build_and_push: descriptive_gcr_path_stem := $(shell git config --get user.name || exit 1)
-build_and_push: descriptive_gcr_path := $(gcr_root)/$(shell echo $(descriptive_gcr_path_stem) | sed 's/[^/A-Za-z0-9_-]/_/g' | tr '[:upper:]' '[:lower:]' || exit 1)
-build_and_push: latest_gcr_tag := latest
-build_and_push: semver_gcr_tag := $(shell cat "$(semver_file)" || exit 1)
-build_and_push: sha_gcr_tag := $(shell git rev-parse --quiet --verify HEAD || exit 1)
-build_and_push: unique_gcr_tag := $(shell date +%s || exit 1)
+build_and_push: sha_gcr_tag := $(shell git rev-parse --short --quiet --verify HEAD || exit 1)
 build_and_push: ## build and push
-	@ if [ -z "$(semver_gcr_tag)" ]; then (printf "\e[31m\tCould not resolve semver_gcr_tag by cat'ing '$(semver_file)'.\e[0m\n" >&2; exit 1); fi
 	@ if [ -z "$(sha_gcr_tag)" ]; then (printf "\e[31m\tCould not resolve sha_gcr_tag with git rev-parse.\e[0m\n" >&2; exit 1); fi
-	@ if [ -z "$(unique_gcr_tag)" ]; then (printf "\e[31m\tCould not resolve unique_gcr_tag with 'date'.\e[0m\n" >&2; exit 1); fi
-	@ if [ "$$(dirname $(descriptive_gcr_path))" = "$$(dirname $(gcr_root))" ]; then (printf "\e[31m\tCould not construct a unique, sanitized GCR path.\e[0m\n" >&2; exit 1); fi
-	docker build --tag $(descriptive_gcr_path):$(latest_gcr_tag) --tag $(descriptive_gcr_path):$(semver_gcr_tag) --tag $(descriptive_gcr_path):$(sha_gcr_tag) --tag $(descriptive_gcr_path):$(unique_gcr_tag) -f docker/Dockerfile .
-	docker push $(descriptive_gcr_path):$(latest_gcr_tag)
-	docker push $(descriptive_gcr_path):$(semver_gcr_tag)
-	docker push $(descriptive_gcr_path):$(sha_gcr_tag)
-	docker push $(descriptive_gcr_path):$(unique_gcr_tag)
-
+	docker build --tag $(gcr_root):$(sha_gcr_tag) -f docker/Dockerfile .
+	docker push $(gcr_root):$(sha_gcr_tag)


### PR DESCRIPTION
Same changes as cdip project

Docker images had to be manually moved between projects because Kubernetes wasn't able to pull the images and it was using Container Registry, which is already deprecated in favor of Artifact Registry. Now all images are going to be stored in cdip-78ca and all projects are going to pull from a single repo.

In this PR we are doing the following:

Upload the docker images to Artifact Registry instead of GCR
Standarize the image path to us-central1-docker.pkg.dev/cdip-78ca/gundi/:<short_hash>
Delete other tags
Comment unnecesary rebuild and push from workflow
Outside this PR, permissions to pull images from cdip-dev, cdip-stage and cdip-prod1 projects was granted