### PR TITLE
SIK-2457: Observations v2 fixes

### DIFF
--- a/app/transform_service/transformers.py
+++ b/app/transform_service/transformers.py
@@ -198,13 +198,13 @@ class ERObservationTransformer(Transformer):
         transformed_message = dict(
             manufacturer_id=message.external_source_id,
             source_type=message.type or "tracking-device",
-            subject_name=message.source_name or message.source_id,
+            subject_name=message.source_name or message.external_source_id,
             recorded_at=message.recorded_at,
             location={"lon": message.location.lon, "lat": message.location.lat},
             additional=message.additional,
         )
 
-        # ER does not except null subject_subtype so conditionally add to transformed position if set
+        # ER does not accept null subject_subtype so conditionally add to transformed position if set
         if subject_type := message.subject_type:
             transformed_message["subject_subtype"] = subject_type
 


### PR DESCRIPTION
### What does this PR do?
- Fixes the transformer for Observations v2 sent to ER sites to map source name to subject name, using the external device id as a fallback. 

### Relevant link(s)
[SIK-2457](https://allenai.atlassian.net/browse/SIK-2457)

[SIK-2457]: https://allenai.atlassian.net/browse/SIK-2457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ