### PR TITLE
GUNDI-2944: Upgrade the gundi client v1 to v1.0.2

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -127,44 +127,44 @@
         "filename": "app/conftest.py",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 261
+        "line_number": 260
       },
       {
         "type": "Hex High Entropy String",
         "filename": "app/conftest.py",
         "hashed_secret": "6be6b429822092d9aae704c5d8f0bb87c8d48a74",
         "is_verified": false,
-        "line_number": 282
+        "line_number": 281
       },
       {
         "type": "Secret Keyword",
         "filename": "app/conftest.py",
         "hashed_secret": "b8499893286e7cd33a9cdcade59aa457ccae525c",
         "is_verified": false,
-        "line_number": 323
+        "line_number": 322
       },
       {
         "type": "Hex High Entropy String",
         "filename": "app/conftest.py",
         "hashed_secret": "ad29fe803b1806aabe6d5345bd12316f523b1138",
         "is_verified": false,
-        "line_number": 412
+        "line_number": 411
       },
       {
         "type": "Hex High Entropy String",
         "filename": "app/conftest.py",
         "hashed_secret": "21bea94c30c25436debb0d3ef112b249a3f0a05a",
         "is_verified": false,
-        "line_number": 620
+        "line_number": 619
       },
       {
         "type": "Secret Keyword",
         "filename": "app/conftest.py",
         "hashed_secret": "9744c10aca40258d875b7702b042ae9730bae146",
         "is_verified": false,
-        "line_number": 960
+        "line_number": 959
       }
     ]
   },
-  "generated_at": "2024-02-09T19:44:50Z"
+  "generated_at": "2024-02-29T14:27:30Z"
 }

--- a/app/conftest.py
+++ b/app/conftest.py
@@ -1,5 +1,6 @@
 import datetime
 import aiohttp
+import httpx
 import pytest
 import uuid
 import asyncio
@@ -117,17 +118,9 @@ def mock_gundi_client_with_client_connector_error_once(
 ):
     mock_client = mocker.MagicMock()
     # Simulate a connection error
-    client_connector_error = aiohttp.ClientConnectorError(
-        connection_key=ConnectionKey(
-            host="cdip-portal.pamdas.org",
-            port=443,
-            is_ssl=True,
-            ssl=True,
-            proxy=None,
-            proxy_auth=None,
-            proxy_headers_hash=None,
-        ),
-        os_error=ConnectionError(),
+    client_connector_error = httpx.ConnectError(
+        message="Connection error",
+        request=httpx.Request("GET", "https://cdip-portal.pamdas.org"),
     )
     _set_side_effect_error_on_gundi_client_once(
         mock_client=mock_client, error=client_connector_error
@@ -145,7 +138,10 @@ def mock_gundi_client_with_server_disconnected_error_once(
 ):
     mock_client = mocker.MagicMock()
     # Simulate a server disconnected error
-    server_disconnected_error = aiohttp.ServerDisconnectedError()
+    server_disconnected_error = httpx.NetworkError(
+        message="Server disconnected",
+        request=httpx.Request("GET", "https://cdip-portal.pamdas.org"),
+    )
     _set_side_effect_error_on_gundi_client_once(
         mock_client=mock_client, error=server_disconnected_error
     )
@@ -161,8 +157,11 @@ def mock_gundi_client_with_server_timeout_error_once(
     device,
 ):
     mock_client = mocker.MagicMock()
-    # Simulate a server disconnected error
-    server_timeout_error = aiohttp.ServerTimeoutError()
+    # Simulate a timeout error
+    server_timeout_error = httpx.TimeoutException(
+        message="Server timeout",
+        request=httpx.Request("GET", "https://cdip-portal.pamdas.org"),
+    )
     _set_side_effect_error_on_gundi_client_once(
         mock_client=mock_client, error=server_timeout_error
     )

--- a/app/subscribers/kafka_subscriber.py
+++ b/app/subscribers/kafka_subscriber.py
@@ -135,8 +135,12 @@ async def send_message_to_kafka_dispatcher(key, message, destination):
         )
 
 
-@backoff.on_exception(backoff.expo, (aiohttp.ClientError, asyncio.TimeoutError), max_tries=20)
-async def send_message_to_gcp_pubsub_dispatcher(message, attributes, destination, broker_config):
+@backoff.on_exception(
+    backoff.expo, (aiohttp.ClientError, asyncio.TimeoutError), max_tries=20
+)
+async def send_message_to_gcp_pubsub_dispatcher(
+    message, attributes, destination, broker_config
+):
     with tracing.tracer.start_as_current_span(  # Trace observations with Open Telemetry
         "routing_service.send_message_to_gcp_pubsub_dispatcher",
         kind=SpanKind.PRODUCER,
@@ -164,9 +168,13 @@ async def send_message_to_gcp_pubsub_dispatcher(message, attributes, destination
             messages = [pubsub.PubsubMessage(message, **attributes)]
             logger.info(f"Sending observation to PubSub topic {topic_name}..")
             try:
-                response = await client.publish(topic, messages, timeout=int(timeout_settings.total))
+                response = await client.publish(
+                    topic, messages, timeout=int(timeout_settings.total)
+                )
             except Exception as e:
-                error_msg = f"Error sending observation to PubSub topic {topic_name}: {e}."
+                error_msg = (
+                    f"Error sending observation to PubSub topic {topic_name}: {e}."
+                )
                 logger.exception(error_msg)
                 current_span.set_attribute("error", error_msg)
                 raise e
@@ -206,14 +214,22 @@ async def process_observation(key, message):
             logger.debug(f"attributes: {attributes}")
             # Get the schema version to process it accordingly
             gundi_version = attributes.get("gundi_version", "v1")
-            observation = convert_observation_to_cdip_schema(raw_observation, gundi_version=gundi_version)
+            observation = convert_observation_to_cdip_schema(
+                raw_observation, gundi_version=gundi_version
+            )
             observation_logging_extra = {
                 ExtraKeys.DeviceId: get_source_id(observation, gundi_version),
-                ExtraKeys.InboundIntId: get_data_provider_id(observation, gundi_version),
+                ExtraKeys.InboundIntId: get_data_provider_id(
+                    observation, gundi_version
+                ),
                 ExtraKeys.StreamType: observation.observation_type,
                 ExtraKeys.GundiVersion: gundi_version,
-                ExtraKeys.GundiId: observation.gundi_id if gundi_version == "v2" else observation.id,
-                ExtraKeys.RelatedTo: observation.related_to if gundi_version == "v2" else ""
+                ExtraKeys.GundiId: observation.gundi_id
+                if gundi_version == "v2"
+                else observation.id,
+                ExtraKeys.RelatedTo: observation.related_to
+                if gundi_version == "v2"
+                else "",
             }
             logger.info(
                 "received unprocessed observation",
@@ -229,15 +245,23 @@ async def process_observation(key, message):
         try:
             if observation:
                 # Process the observation differently according to the Gundi Version
-                await apply_source_configurations(observation=observation, gundi_version=gundi_version)
+                await apply_source_configurations(
+                    observation=observation, gundi_version=gundi_version
+                )
                 if gundi_version == "v2":
                     # ToDo: Implement a destination resolution algorithm considering all the routes and filters
-                    connection = await get_connection(connection_id=observation.data_provider_id)
+                    connection = await get_connection(
+                        connection_id=observation.data_provider_id
+                    )
                     provider = connection.provider
                     destinations = connection.destinations
-                    default_route = await get_route(route_id=connection.default_route.id)
+                    default_route = await get_route(
+                        route_id=connection.default_route.id
+                    )
                     route_configuration = default_route.configuration
-                    provider_key = get_provider_key(provider)  # i.e. gundi_cellstop_abc1234..
+                    provider_key = get_provider_key(
+                        provider
+                    )  # i.e. gundi_cellstop_abc1234..
                 else:  # Default to v1
                     provider = None
                     route_configuration = None
@@ -256,11 +280,17 @@ async def process_observation(key, message):
                     logger.warning(
                         "Updating observation with Device info, but it has no Destinations. This is a configuration error.",
                         extra={
-                            ExtraKeys.DeviceId: get_source_id(observation, gundi_version),
-                            ExtraKeys.InboundIntId: get_data_provider_id(observation, gundi_version),
+                            ExtraKeys.DeviceId: get_source_id(
+                                observation, gundi_version
+                            ),
+                            ExtraKeys.InboundIntId: get_data_provider_id(
+                                observation, gundi_version
+                            ),
                             ExtraKeys.StreamType: observation.observation_type,
                             ExtraKeys.GundiVersion: gundi_version,
-                            ExtraKeys.GundiId: observation.gundi_id if gundi_version == "v2" else observation.id,
+                            ExtraKeys.GundiId: observation.gundi_id
+                            if gundi_version == "v2"
+                            else observation.id,
                             ExtraKeys.AttentionNeeded: True,
                         },
                     )
@@ -268,17 +298,23 @@ async def process_observation(key, message):
                 for destination in destinations:
                     # Get additional configuration for the destination
                     if gundi_version == "v2":
-                        destination_integration = await get_integration(integration_id=destination.id)
+                        destination_integration = await get_integration(
+                            integration_id=destination.id
+                        )
                         broker_config = destination_integration.additional
                     else:
                         broker_config = destination.additional
                     # Transform the observation for the destination
-                    transformed_observation = await transform_observation_to_destination_schema(
-                        observation=observation,
-                        destination=destination_integration if gundi_version == "v2" else destination,
-                        provider=provider,
-                        route_configuration=route_configuration,
-                        gundi_version=gundi_version
+                    transformed_observation = (
+                        await transform_observation_to_destination_schema(
+                            observation=observation,
+                            destination=destination_integration
+                            if gundi_version == "v2"
+                            else destination,
+                            provider=provider,
+                            route_configuration=route_configuration,
+                            gundi_version=gundi_version,
+                        )
                     )
                     if not transformed_observation:
                         continue
@@ -286,13 +322,15 @@ async def process_observation(key, message):
                         observation=observation,
                         destination=destination,
                         gundi_version=gundi_version,
-                        provider_key=provider_key
+                        provider_key=provider_key,
                     )
                     logger.debug(
                         f"Transformed observation: {transformed_observation}, attributes: {attributes}"
                     )
 
-                    broker_type = broker_config.get("broker", Broker.KAFKA.value).strip().lower()
+                    broker_type = (
+                        broker_config.get("broker", Broker.KAFKA.value).strip().lower()
+                    )
                     current_span.set_attribute("broker", broker_type)
                     if broker_type not in supported_brokers:
                         raise ReferenceDataError(
@@ -314,7 +352,7 @@ async def process_observation(key, message):
                             extra={
                                 **observation_logging_extra,
                                 **attributes,
-                                "destination_id": str(destination.id)
+                                "destination_id": str(destination.id),
                             },
                         )
                     elif broker_type == Broker.GCP_PUBSUB.value:
@@ -325,14 +363,14 @@ async def process_observation(key, message):
                             message=pubsub_message,
                             attributes=attributes,
                             destination=destination,
-                            broker_config=broker_config
+                            broker_config=broker_config,
                         )
                         logger.info(
                             "Observation transformed and sent to pubsub topic successfully.",
                             extra={
                                 **observation_logging_extra,
                                 **attributes,
-                                "destination_id": str(destination.id)
+                                "destination_id": str(destination.id),
                             },
                         )
             else:
@@ -340,18 +378,22 @@ async def process_observation(key, message):
                     "Logic error, expecting 'observation' to be not None.",
                     extra={
                         ExtraKeys.DeviceId: get_source_id(observation, gundi_version),
-                        ExtraKeys.InboundIntId: get_data_provider_id(observation, gundi_version),
+                        ExtraKeys.InboundIntId: get_data_provider_id(
+                            observation, gundi_version
+                        ),
                         ExtraKeys.StreamType: observation.observation_type,
                         ExtraKeys.AttentionNeeded: True,
                     },
                 )
-        except ReferenceDataError:
+        except ReferenceDataError as e:
             logger.exception(
-                f"External error occurred obtaining reference data for observation",
+                f"External error occurred obtaining reference data for observation: {e}",
                 extra={
                     ExtraKeys.AttentionNeeded: True,
                     ExtraKeys.DeviceId: get_source_id(observation, gundi_version),
-                    ExtraKeys.InboundIntId: get_data_provider_id(observation, gundi_version),
+                    ExtraKeys.InboundIntId: get_data_provider_id(
+                        observation, gundi_version
+                    ),
                     ExtraKeys.StreamType: observation.observation_type,
                 },
             )
@@ -367,7 +409,9 @@ async def process_observation(key, message):
                     ExtraKeys.AttentionNeeded: True,
                     ExtraKeys.DeadLetter: True,
                     ExtraKeys.DeviceId: get_source_id(observation, gundi_version),
-                    ExtraKeys.InboundIntId: get_data_provider_id(observation, gundi_version),
+                    ExtraKeys.InboundIntId: get_data_provider_id(
+                        observation, gundi_version
+                    ),
                     ExtraKeys.StreamType: observation.observation_type,
                 },
             )

--- a/requirements.in
+++ b/requirements.in
@@ -15,7 +15,7 @@ packaging==23.0
 https://github.com/PADAS/er-client/releases/download/v1.2.0-alpha/earthranger_client-1.2.0-py3-none-any.whl
 https://github.com/PADAS/smart-integrate-sdk/releases/download/v1.3.2/cdip_connector-1.3.2-py3-none-any.whl
 https://github.com/PADAS/smartconnect-client/releases/download/v1.5.1/smartconnect_client-1.5.1-py3-none-any.whl
-gundi-client==0.2.2
+gundi-client==1.0.2
 gundi-client-v2==2.1.7
 gundi-core==1.2.10
 opentelemetry-api==1.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ aiohttp==3.8.5
     #   cdip-connector
     #   faust
     #   gcloud-aio-auth
-    #   gundi-client
 aiohttp-cors==0.7.0
     # via faust
 aioredis==2.0.1
@@ -102,7 +101,6 @@ gcloud-aio-pubsub==5.2.0
     # via -r requirements.in
 google-api-core[grpc]==2.11.1
     # via
-    #   google-api-core
     #   google-cloud-core
     #   google-cloud-pubsub
     #   google-cloud-storage
@@ -149,13 +147,14 @@ grpcio-status==1.48.2
     # via
     #   google-api-core
     #   google-cloud-pubsub
-gundi-client==0.2.2
+gundi-client==1.0.2
     # via -r requirements.in
 gundi-client-v2==2.1.7
     # via -r requirements.in
 gundi-core==1.2.10
     # via
     #   -r requirements.in
+    #   gundi-client
     #   gundi-client-v2
 h11==0.14.0
     # via
@@ -168,6 +167,7 @@ httpcore==0.17.3
 httpx==0.24.1
     # via
     #   earthranger-client
+    #   gundi-client
     #   gundi-client-v2
     #   respx
     #   smartconnect-client
@@ -351,7 +351,9 @@ requests==2.28.1
     #   opentelemetry-exporter-otlp-proto-http
     #   smartconnect-client
 respx==0.20.2
-    # via gundi-client-v2
+    # via
+    #   gundi-client
+    #   gundi-client-v2
 robinhood-aiokafka==1.1.6
     # via faust
 rsa==4.9


### PR DESCRIPTION
### What does this PR do?
- Upgrades the gundi client from v0.22 to v 1.0.2 which includes error handling to re-authenticate when a call to the portal returns a redirect to the keycloak site.
- This involves some refactoring as the major version change includes breaking changes (switched from aiohttp to httpx)
- Mocks used in unit tests are refactored accordingly

### Relevant link(s)
[GUNDI-2944](https://allenai.atlassian.net/browse/GUNDI-2944)

[GUNDI-2944]: https://allenai.atlassian.net/browse/GUNDI-2944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ