### PR TITLE
GUNDI-2944: Upgrade the gundi client v1 to v1.0.2

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -127,44 +127,44 @@
         "filename": "app/conftest.py",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 232
+        "line_number": 231
       },
       {
         "type": "Hex High Entropy String",
         "filename": "app/conftest.py",
         "hashed_secret": "6be6b429822092d9aae704c5d8f0bb87c8d48a74",
         "is_verified": false,
-        "line_number": 253
+        "line_number": 252
       },
       {
         "type": "Secret Keyword",
         "filename": "app/conftest.py",
         "hashed_secret": "b8499893286e7cd33a9cdcade59aa457ccae525c",
         "is_verified": false,
-        "line_number": 300
+        "line_number": 299
       },
       {
         "type": "Hex High Entropy String",
         "filename": "app/conftest.py",
         "hashed_secret": "ad29fe803b1806aabe6d5345bd12316f523b1138",
         "is_verified": false,
-        "line_number": 774
+        "line_number": 773
       },
       {
         "type": "Hex High Entropy String",
         "filename": "app/conftest.py",
         "hashed_secret": "21bea94c30c25436debb0d3ef112b249a3f0a05a",
         "is_verified": false,
-        "line_number": 927
+        "line_number": 926
       },
       {
         "type": "Secret Keyword",
         "filename": "app/conftest.py",
         "hashed_secret": "9744c10aca40258d875b7702b042ae9730bae146",
         "is_verified": false,
-        "line_number": 1321
+        "line_number": 1320
       }
     ]
   },
-  "generated_at": "2024-02-22T12:52:46Z"
+  "generated_at": "2024-02-29T21:31:55Z"
 }

--- a/app/conftest.py
+++ b/app/conftest.py
@@ -1,5 +1,6 @@
 import datetime
 import aiohttp
+import httpx
 import pytest
 import uuid
 import asyncio
@@ -114,17 +115,9 @@ def mock_gundi_client_with_client_connector_error_once(
 ):
     mock_client = mocker.MagicMock()
     # Simulate a connection error
-    client_connector_error = aiohttp.ClientConnectorError(
-        connection_key=ConnectionKey(
-            host="cdip-portal.pamdas.org",
-            port=443,
-            is_ssl=True,
-            ssl=True,
-            proxy=None,
-            proxy_auth=None,
-            proxy_headers_hash=None,
-        ),
-        os_error=ConnectionError(),
+    client_connector_error = httpx.ConnectError(
+        message="Connection error",
+        request=httpx.Request("GET", "https://cdip-portal.pamdas.org"),
     )
     _set_side_effect_error_on_gundi_client_once(
         mock_client=mock_client, error=client_connector_error
@@ -142,7 +135,10 @@ def mock_gundi_client_with_server_disconnected_error_once(
 ):
     mock_client = mocker.MagicMock()
     # Simulate a server disconnected error
-    server_disconnected_error = aiohttp.ServerDisconnectedError()
+    server_disconnected_error = httpx.NetworkError(
+        message="Server disconnected",
+        request=httpx.Request("GET", "https://cdip-portal.pamdas.org"),
+    )
     _set_side_effect_error_on_gundi_client_once(
         mock_client=mock_client, error=server_disconnected_error
     )
@@ -158,8 +154,11 @@ def mock_gundi_client_with_server_timeout_error_once(
     device,
 ):
     mock_client = mocker.MagicMock()
-    # Simulate a server disconnected error
-    server_timeout_error = aiohttp.ServerTimeoutError()
+    # Simulate a timeout error
+    server_timeout_error = httpx.TimeoutException(
+        message="Server timeout",
+        request=httpx.Request("GET", "https://cdip-portal.pamdas.org"),
+    )
     _set_side_effect_error_on_gundi_client_once(
         mock_client=mock_client, error=server_timeout_error
     )

--- a/requirements.in
+++ b/requirements.in
@@ -12,7 +12,7 @@ hiredis==2.3.2
 packaging==23.0
 https://github.com/PADAS/er-client/releases/download/v1.2.0-alpha/earthranger_client-1.2.0-py3-none-any.whl
 https://github.com/PADAS/smartconnect-client/releases/download/v1.5.1/smartconnect_client-1.5.1-py3-none-any.whl
-gundi-client==0.2.2
+gundi-client==1.0.2
 gundi-client-v2==2.1.7
 gundi-core==1.3.0
 opentelemetry-api==1.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,9 +7,7 @@
 aiofiles==23.2.1
     # via gcloud-aio-storage
 aiohttp==3.8.5
-    # via
-    #   gcloud-aio-auth
-    #   gundi-client
+    # via gcloud-aio-auth
 aioredis==2.0.1
     # via -r requirements.in
 aiosignal==1.3.1
@@ -105,13 +103,14 @@ grpcio==1.56.2
     #   grpcio-status
 grpcio-status==1.48.2
     # via google-api-core
-gundi-client==0.2.2
+gundi-client==1.0.2
     # via -r requirements.in
 gundi-client-v2==2.1.7
     # via -r requirements.in
 gundi-core==1.3.0
     # via
     #   -r requirements.in
+    #   gundi-client
     #   gundi-client-v2
 h11==0.14.0
     # via
@@ -124,6 +123,7 @@ httpcore==0.17.3
 httpx==0.24.1
     # via
     #   earthranger-client
+    #   gundi-client
     #   gundi-client-v2
     #   respx
     #   smartconnect-client
@@ -266,7 +266,9 @@ requests==2.28.1
     #   opentelemetry-exporter-otlp-proto-http
     #   smartconnect-client
 respx==0.20.2
-    # via gundi-client-v2
+    # via
+    #   gundi-client
+    #   gundi-client-v2
 rsa==4.9
     # via
     #   gcloud-aio-storage


### PR DESCRIPTION
### What does this PR do?
- Upgrades the gundi client from v0.22 to v 1.0.2 which includes error handling to re-authenticate when a call to the portal returns a redirect to the keycloak site.
- This involves some refactoring as the major version change includes breaking changes (switched from aiohttp to httpx)
- Mocks used in unit tests are refactored accordingly

### Relevant link(s)
[GUNDI-2944](https://allenai.atlassian.net/browse/GUNDI-2944)

[GUNDI-2944]: https://allenai.atlassian.net/browse/GUNDI-2944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ