### PR TITLE
GUNDI-3168: Fix issues in SMART transformer

### DIFF
--- a/app/conftest.py
+++ b/app/conftest.py
@@ -1499,7 +1499,7 @@ def destination_integration_v2_smart(integration_type_smart, smart_ca_uuid):
             schemas_v2.IntegrationActionConfiguration(
                 id=UUID("55760315-3d68-4925-bf2d-c4d39de433c9"),
                 integration=UUID("b42c9205-5228-49e0-a75b-ebe5b6a9f78e"),
-                action=schemas_v2.IntegrationActionSummery(
+                action=schemas_v2.IntegrationActionSummary(
                     id=UUID("ebe72917-c112-4064-9f38-707bbd14a50f"),
                     type="push",
                     name="Push Events",
@@ -1514,7 +1514,7 @@ def destination_integration_v2_smart(integration_type_smart, smart_ca_uuid):
             schemas_v2.IntegrationActionConfiguration(
                 id=UUID("abce8c67-a74c-46fd-b5c3-62a7b76f2b17"),
                 integration=UUID("b42c9205-5228-49e0-a75b-ebe5b6a9f78e"),
-                action=schemas_v2.IntegrationActionSummery(
+                action=schemas_v2.IntegrationActionSummary(
                     id=UUID("b0a0e7ed-d668-41b5-96d2-397f026c4ecb"),
                     type="auth",
                     name="Authenticate",

--- a/app/services/transformers.py
+++ b/app/services/transformers.py
@@ -939,9 +939,20 @@ class SMARTTransformerV2(Transformer, ABC):
 
         self._version = self.auth_config.version or "7.5"
         logger.info(f"Using SMART Integration version {self._version}")
-
+        url_parse = urlparse(self.config.base_url)
+        domain = (
+            f"{url_parse.hostname}:{url_parse.port}"
+            if url_parse.port
+            else url_parse.hostname
+        )
+        path = url_parse.path or "/server"
+        path = path.replace("//", "/")
+        api_url = (
+                getattr(auth_config, "endpoint", None)
+                or f"{url_parse.scheme}://{domain}{path}"
+        )
         self.smartconnect_client = AsyncSmartClient(
-            api=f"{self.config.base_url}/server",
+            api=api_url,
             username=self.auth_config.login,
             password=self.auth_config.password,
             version=self._version,

--- a/requirements.in
+++ b/requirements.in
@@ -11,10 +11,10 @@ aioredis==2.0.1
 hiredis==2.3.2
 packaging==23.0
 https://github.com/PADAS/er-client/releases/download/v1.2.0-alpha/earthranger_client-1.2.0-py3-none-any.whl
-https://github.com/PADAS/smartconnect-client/releases/download/v1.5.1/smartconnect_client-1.5.1-py3-none-any.whl
+https://github.com/PADAS/smartconnect-client/releases/download/v1.5.3/smartconnect_client-1.5.3-py3-none-any.whl
 gundi-client==1.0.2
-gundi-client-v2==2.2.0
-gundi-core==1.3.0
+gundi-client-v2==2.3.0
+gundi-core==1.4.0
 opentelemetry-api==1.14.0
 opentelemetry-sdk==1.14.0
 opentelemetry-exporter-gcp-trace==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -105,9 +105,9 @@ grpcio-status==1.48.2
     # via google-api-core
 gundi-client==1.0.2
     # via -r requirements.in
-gundi-client-v2==2.2.0
+gundi-client-v2==2.3.0
     # via -r requirements.in
-gundi-core==1.3.0
+gundi-core==1.4.0
     # via
     #   -r requirements.in
     #   gundi-client
@@ -279,7 +279,7 @@ six==1.16.0
     # via
     #   google-auth
     #   python-dateutil
-smartconnect-client @ https://github.com/PADAS/smartconnect-client/releases/download/v1.5.1/smartconnect_client-1.5.1-py3-none-any.whl
+smartconnect-client @ https://github.com/PADAS/smartconnect-client/releases/download/v1.5.3/smartconnect_client-1.5.3-py3-none-any.whl
     # via -r requirements.in
 sniffio==1.3.0
     # via


### PR DESCRIPTION
### What does this PR do?
- Fixes issue in smart transformer v2 to allow custom paths in smart site URLs (for cases like tfuas).
- Upgrades the smartconnect client to the latest version to avoid using basic-auth
- Upgrades the gundi client to the latest version


### Relevant link(s)
[GUNDI-3168](https://allenai.atlassian.net/browse/GUNDI-3168)

[GUNDI-3168]: https://allenai.atlassian.net/browse/GUNDI-3168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ