### PR TITLE
GUNDI-2964: Event updates for ER

### DIFF
--- a/app/conftest.py
+++ b/app/conftest.py
@@ -1092,6 +1092,49 @@ def route_v2():
 
 
 @pytest.fixture
+def raw_observation_v2():
+    return {
+        "event_id": "d8523635-546e-4cd4-ad6a-d9fdf494698e",
+        "timestamp": "2024-07-22 11:51:12.684788+00:00",
+        "schema_version": "v1",
+        "payload": {
+            "gundi_id": "9573c2b0-3fd7-4502-884b-43d5628ce7a8",
+            "related_to": None,
+            "owner": "a91b400b-482a-4546-8fcb-ee42b01deeb6",
+            "data_provider_id": "f870e228-4a65-40f0-888c-41bdc1124c3c",
+            "annotations": {},
+            "source_id": "eb47e6ad-a677-4218-856b-59ad4d8d0e73",
+            "external_source_id": "test-device",
+            "source_name": "Mariano",
+            "type": "tracking-device",
+            "subject_type": "mm-tracker",
+            "recorded_at": "2024-07-22 11:51:05+00:00",
+            "location": {
+                "lat": -51.688246,
+                "lon": -72.704459,
+                "alt": 0,
+                "hdop": None,
+                "vdop": None
+            },
+            "additional": {
+                "speed_kmph": 30
+            },
+            "observation_type": "obv"
+        },
+        "event_type": "ObservationReceived"
+    }
+
+
+@pytest.fixture
+def raw_observation_v2_attributes():
+    return {
+        "observation_type": "obv",
+        "gundi_version": "v2",
+        "gundi_id": "9573c2b0-3fd7-4502-884b-43d5628ce7a8",
+    }
+
+
+@pytest.fixture
 def raw_event_v2():
     return {
         "event_type": "EventReceived",
@@ -1123,6 +1166,40 @@ def raw_event_v2_attributes():
         "observation_type": "ev",
         "gundi_version": "v2",
         "gundi_id": "5b793d17-cd79-49c8-abaa-712cb40f2b54",
+    }
+
+
+@pytest.fixture
+def raw_event_update():
+    return {
+        "event_id": "04532433-79d3-4265-a201-7b920582c7e7",
+        "timestamp": "2024-07-22 12:23:20.449844+00:00",
+        "schema_version": "v1",
+        "payload": {
+            "gundi_id": "b1fd63df-9337-40bf-8097-307d986d7e94",
+            "related_to": None,
+            "owner": "a91b400b-482a-4546-8fcb-ee42b01deeb6",
+            "data_provider_id": "f870e228-4a65-40f0-888c-41bdc1124c3c",
+            "annotations": None,
+            "source_id": "ac1b9cdc-a193-4515-b446-b177bcc5f342",
+            "external_source_id": "camera123",
+            "changes": {
+                "event_details": {
+                    "species": "wildcat"
+                }
+            },
+            "observation_type": "evu"
+        },
+        "event_type": "EventUpdateReceived"
+    }
+
+
+@pytest.fixture
+def raw_event_update_attributes():
+    return {
+        "observation_type": "evu",
+        "gundi_version": "v2",
+        "gundi_id": "b1fd63df-9337-40bf-8097-307d986d7e94",
     }
 
 
@@ -1206,6 +1283,25 @@ def leopard_detected_from_species_event_v2():
         },
         geometry={},
         observation_type="ev",
+    )
+
+
+@pytest.fixture
+def event_update_species_wildcat():
+    return schemas_v2.EventUpdate(
+        gundi_id="78867a74-67f0-4b56-8e44-125ae66408ff",
+        related_to=None,
+        owner="a91b400b-482a-4546-8fcb-ee42b01deeb6",
+        data_provider_id="ddd0946d-15b0-4308-b93d-e0470b6d33b6",
+        annotations=None,
+        source_id="ac1b9cdc-a193-4515-b446-b177bcc5f342",
+        external_source_id="camera123",
+        changes={
+            "event_details": {
+                "species": "Wildcat"
+            }
+        },
+        observation_type="evu"
     )
 
 
@@ -1579,6 +1675,19 @@ def route_config_with_event_type_mappings():
                             "map": {
                                 "Leopard": "leopard_sighting",
                                 "Wilddog": "wild_dog_sighting",
+                                "Wildcat": "wild_cat_sighting",
+                            },
+                            "default": "wildlife_sighting_rep",
+                            "provider_field": "event_details__species",
+                            "destination_field": "event_type",
+                        }
+                    },
+                    "evu": {
+                        "338225f3-91f9-4fe1-b013-353a229ce504": {
+                            "map": {
+                                "Leopard": "leopard_sighting",
+                                "Wilddog": "wild_dog_sighting",
+                                "Wildcat": "wild_cat_sighting",
                             },
                             "default": "wildlife_sighting_rep",
                             "provider_field": "event_details__species",

--- a/app/conftest.py
+++ b/app/conftest.py
@@ -34,11 +34,11 @@ def mock_cache(mocker):
 
 @pytest.fixture
 def mock_gundi_client(
-    mocker,
-    inbound_integration_config,
-    outbound_integration_config,
-    outbound_integration_config_list,
-    device,
+        mocker,
+        inbound_integration_config,
+        outbound_integration_config,
+        outbound_integration_config_list,
+        device,
 ):
     mock_client = mocker.MagicMock()
     mock_client.get_inbound_integration.return_value = async_return(
@@ -107,11 +107,11 @@ def _set_side_effect_error_on_gundi_client_once(mock_client, error):
 
 @pytest.fixture
 def mock_gundi_client_with_client_connector_error_once(
-    mocker,
-    inbound_integration_config,
-    outbound_integration_config,
-    outbound_integration_config_list,
-    device,
+        mocker,
+        inbound_integration_config,
+        outbound_integration_config,
+        outbound_integration_config_list,
+        device,
 ):
     mock_client = mocker.MagicMock()
     # Simulate a connection error
@@ -127,11 +127,11 @@ def mock_gundi_client_with_client_connector_error_once(
 
 @pytest.fixture
 def mock_gundi_client_with_server_disconnected_error_once(
-    mocker,
-    inbound_integration_config,
-    outbound_integration_config,
-    outbound_integration_config_list,
-    device,
+        mocker,
+        inbound_integration_config,
+        outbound_integration_config,
+        outbound_integration_config_list,
+        device,
 ):
     mock_client = mocker.MagicMock()
     # Simulate a server disconnected error
@@ -147,11 +147,11 @@ def mock_gundi_client_with_server_disconnected_error_once(
 
 @pytest.fixture
 def mock_gundi_client_with_server_timeout_error_once(
-    mocker,
-    inbound_integration_config,
-    outbound_integration_config,
-    outbound_integration_config_list,
-    device,
+        mocker,
+        inbound_integration_config,
+        outbound_integration_config,
+        outbound_integration_config_list,
+        device,
 ):
     mock_client = mocker.MagicMock()
     # Simulate a timeout error
@@ -825,10 +825,10 @@ def outbound_configuration_default():
 # ToDo: Find a common place for mocks and testing utilities that can be reused across services
 @pytest.fixture
 def mock_gundi_client_v2(
-    mocker,
-    connection_v2,
-    destination_integration_v2,
-    route_v2,
+        mocker,
+        connection_v2,
+        destination_integration_v2,
+        route_v2,
 ):
     mock_client = mocker.MagicMock()
     mock_client.get_connection_details.return_value = async_return(connection_v2)
@@ -1094,31 +1094,26 @@ def route_v2():
 @pytest.fixture
 def raw_event_v2():
     return {
-        "gundi_id": "5b793d17-cd79-49c8-abaa-712cb40f2b54",
-        "related_to": "None",
-        "owner": "e2d1b0fc-69fe-408b-afc5-7f54872730c0",
-        "data_provider_id": "ddd0946d-15b0-4308-b93d-e0470b6d33b6",
-        "annotations": {},
-        "source_id": "afa0d606-c143-4705-955d-68133645db6d",
-        "external_source_id": "Xyz123",
-        "recorded_at": "2023-07-04T21:38:00+00:00",
-        "location": {
-            "lat": -51.667875,
-            "lon": -72.71195,
-            "alt": 1800.0,
-            "hdop": None,
-            "vdop": None,
-        },
-        "title": "Animal Detected",
-        "event_type": None,
-        "event_details": {
-            "site_name": "Camera2G",
-            "species": "Leopard",
-            "tags": ["female adult", "male child"],
-            "animal_count": 2,
-        },
-        "geometry": {},
-        "observation_type": "ev",
+        "event_type": "EventReceived",
+        "event_id": "21bda0d3-b2de-4285-9540-0b6a84881b52",
+        "timestamp": "2024-07-04 18:09:19.853663+00:00",
+        "schema_version": "v1",
+        "payload": {
+            "gundi_id": "27e9329e-82ab-44f9-8997-b09f123eccbb",
+            "related_to": None,
+            "owner": "a91b400b-482a-4546-8fcb-ee42b01deeb6",
+            "data_provider_id": "f870e228-4a65-40f0-888c-41bdc1124c3c",
+            "annotations": {},
+            "source_id": "ac1b9cdc-a193-4515-b446-b177bcc5f342",
+            "external_source_id": "camera123",
+            "recorded_at": "2024-07-04 18:09:12+00:00",
+            "location": {"lat": 13.688635, "lon": 13.783064, "alt": 0.0, "hdop": None, "vdop": None},
+            "title": "Animal Detected Test Event",
+            "event_type": "wildlife_sighting_rep",
+            "event_details": {"species": "lion"},
+            "geometry": {},
+            "observation_type": "ev"
+        }
     }
 
 
@@ -1134,15 +1129,20 @@ def raw_event_v2_attributes():
 @pytest.fixture
 def raw_attachment_v2():
     return {
-        "gundi_id": "8b62fdd5-2e70-40e1-b202-f80c6014d596",
-        "related_to": "5b793d17-cd79-49c8-abaa-712cb40f2b54",
-        "owner": "na",
-        "data_provider_id": "ddd0946d-15b0-4308-b93d-e0470b6d33b6",
-        "annotations": None,
-        "source_id": "None",
-        "external_source_id": "None",
-        "file_path": "attachments/8b62fdd5-2e70-40e1-b202-f80c6014d596_2023-07-04-1851_leopard.jpg",
-        "observation_type": "att",
+        "event_type": "AttachmentReceived",
+        "event_id": "6fe6c88a-3b48-4294-8dbb-2dec5d911f71",
+        "timestamp": "2024-07-19T19:41:31.866487Z",
+        "schema_version": "v1",
+        "payload": {
+            "gundi_id": "7687a8d5-a89d-4ceb-be3b-5e1e3b7dc1a9",
+            "related_to": "5f0b33b0-cf0d-4280-990f-0096c357b6c5",
+            "owner": "na", "data_provider_id": "f870e228-4a65-40f0-888c-41bdc1124c3c",
+            "annotations": None,
+            "source_id": "None",
+            "external_source_id": "None",
+            "file_path": "attachments/7687a8d5-a89d-4ceb-be3b-5e1e3b7dc1a9_elephant-female.png",
+            "observation_type": "att"
+        }
     }
 
 
@@ -1157,6 +1157,33 @@ def raw_attachment_v2_attributes():
 
 @pytest.fixture
 def leopard_detected_event_v2():
+    return schemas_v2.Event(
+        gundi_id="b9b46dc1-e033-447d-a99b-0fe373ca04c9",
+        related_to="None",
+        owner="e2d1b0fc-69fe-408b-afc5-7f54872730c0",
+        data_provider_id="ddd0946d-15b0-4308-b93d-e0470b6d33b6",
+        annotations={},
+        source_id="afa0d606-c143-4705-955d-68133645db6d",
+        external_source_id="Xyz123",
+        recorded_at=datetime.datetime(2023, 7, 4, 21, 38, tzinfo=datetime.timezone.utc),
+        location=schemas_v2.Location(
+            lat=-51.667875, lon=-72.71195, alt=1800.0, hdop=None, vdop=None
+        ),
+        title="Leopard Detected",
+        event_type="leopard_sighting",
+        event_details={
+            "site_name": "Camera2G",
+            "species": "Leopard",
+            "tags": ["female adult", "male child"],
+            "animal_count": 2,
+        },
+        geometry={},
+        observation_type="ev",
+    )
+
+
+@pytest.fixture
+def leopard_detected_from_species_event_v2():
     return schemas_v2.Event(
         gundi_id="b9b46dc1-e033-447d-a99b-0fe373ca04c9",
         related_to="None",
@@ -1612,7 +1639,8 @@ def geoevent_v1_cloud_event_payload():
                 "integration_id": "c25a53f6-e206-43dd-8f62-a3759565ae3d",
                 "tracing_context": "{}",
             },
-            "data": "eyJpZCI6IG51bGwsICJvd25lciI6ICJuYSIsICJpbnRlZ3JhdGlvbl9pZCI6ICJjMjVhNTNmNi1lMjA2LTQzZGQtOGY2Mi1hMzc1OTU2NWFlM2QiLCAiZGV2aWNlX2lkIjogIm5vbmUiLCAicmVjb3JkZWRfYXQiOiAiMjAyNC0wMi0yMCAyMDozNDowOC0wMzowMCIsICJsb2NhdGlvbiI6IHsieCI6IC01MS42ODg2NzUsICJ5IjogLTcyLjcwNDQ2NSwgInoiOiAwLjAsICJoZG9wIjogbnVsbCwgInZkb3AiOiBudWxsfSwgImFkZGl0aW9uYWwiOiBudWxsLCAidGl0bGUiOiAiUG9hY2hlcnMgQWN0aXZpdHkiLCAiZXZlbnRfdHlwZSI6ICJodW1hbmFjdGl2aXR5X3BvYWNoaW5nIiwgImV2ZW50X2RldGFpbHMiOiB7fSwgImdlb21ldHJ5IjogbnVsbCwgIm9ic2VydmF0aW9uX3R5cGUiOiAiZ2UifQ==",  # pragma: allowlist secret
+            "data": "eyJpZCI6IG51bGwsICJvd25lciI6ICJuYSIsICJpbnRlZ3JhdGlvbl9pZCI6ICJjMjVhNTNmNi1lMjA2LTQzZGQtOGY2Mi1hMzc1OTU2NWFlM2QiLCAiZGV2aWNlX2lkIjogIm5vbmUiLCAicmVjb3JkZWRfYXQiOiAiMjAyNC0wMi0yMCAyMDozNDowOC0wMzowMCIsICJsb2NhdGlvbiI6IHsieCI6IC01MS42ODg2NzUsICJ5IjogLTcyLjcwNDQ2NSwgInoiOiAwLjAsICJoZG9wIjogbnVsbCwgInZkb3AiOiBudWxsfSwgImFkZGl0aW9uYWwiOiBudWxsLCAidGl0bGUiOiAiUG9hY2hlcnMgQWN0aXZpdHkiLCAiZXZlbnRfdHlwZSI6ICJodW1hbmFjdGl2aXR5X3BvYWNoaW5nIiwgImV2ZW50X2RldGFpbHMiOiB7fSwgImdlb21ldHJ5IjogbnVsbCwgIm9ic2VydmF0aW9uX3R5cGUiOiAiZ2UifQ==",
+            # pragma: allowlist secret
             "messageId": "8255786613739820",
             "message_id": "8255786613739820",
             "publishTime": timestamp,
@@ -1641,7 +1669,8 @@ def geoevent_v2_cloud_event_payload():
                 "stream_type": "ev",
                 "tracing_context": "{}",
             },
-            "data": "eyJjYV91dWlkIjogIjRiMjMyNDJhLTExNjEtNDZjMy1hZjg0LTVlMzVkYzgwMWM0MyIsICJwYXRyb2xfcmVxdWVzdHMiOiBbXSwgIndheXBvaW50X3JlcXVlc3RzIjogW3sidHlwZSI6ICJGZWF0dXJlIiwgImdlb21ldHJ5IjogeyJjb29yZGluYXRlcyI6IFstNzIuNzA0NDI1LCAtNTEuNjg4NjQ1XX0sICJwcm9wZXJ0aWVzIjogeyJkYXRlVGltZSI6ICIyMDI0LTAxLTA4VDA5OjUxOjE0IiwgInNtYXJ0RGF0YVR5cGUiOiAiaW5jaWRlbnQiLCAic21hcnRGZWF0dXJlVHlwZSI6ICJ3YXlwb2ludC9uZXciLCAic21hcnRBdHRyaWJ1dGVzIjogeyJvYnNlcnZhdGlvbkdyb3VwcyI6IFt7Im9ic2VydmF0aW9ucyI6IFt7Im9ic2VydmF0aW9uVXVpZCI6ICI0NGVhZjc5OC1mYTg3LTQ4ZDktOWJhZi00MmRmZGI0YzYyMzEiLCAiY2F0ZWdvcnkiOiAiYW5pbWFscy5zaWduIiwgImF0dHJpYnV0ZXMiOiB7InNwZWNpZXMiOiAibGlvbiJ9fV19XSwgInBhdHJvbFV1aWQiOiBudWxsLCAicGF0cm9sTGVnVXVpZCI6IG51bGwsICJwYXRyb2xJZCI6IG51bGwsICJpbmNpZGVudElkIjogImd1bmRpX2V2XzQ0ZWFmNzk4LWZhODctNDhkOS05YmFmLTQyZGZkYjRjNjIzMSIsICJpbmNpZGVudFV1aWQiOiAiNDRlYWY3OTgtZmE4Ny00OGQ5LTliYWYtNDJkZmRiNGM2MjMxIiwgInRlYW0iOiBudWxsLCAib2JqZWN0aXZlIjogbnVsbCwgImNvbW1lbnQiOiAiUmVwb3J0OiBBbmltYWxzIFNpZ25cbkltcG9ydGVkOiAyMDI0LTAxLTA4VDEwOjQwOjU5LjU4MzE4MC0wMzowMCIsICJpc0FybWVkIjogbnVsbCwgInRyYW5zcG9ydFR5cGUiOiBudWxsLCAibWFuZGF0ZSI6IG51bGwsICJudW1iZXIiOiBudWxsLCAibWVtYmVycyI6IG51bGwsICJsZWFkZXIiOiBudWxsLCAiYXR0YWNobWVudHMiOiBudWxsfX19XSwgInRyYWNrX3BvaW50X3JlcXVlc3RzIjogW119",  # pragma: allowlist secret
+            "data": "eyJjYV91dWlkIjogIjRiMjMyNDJhLTExNjEtNDZjMy1hZjg0LTVlMzVkYzgwMWM0MyIsICJwYXRyb2xfcmVxdWVzdHMiOiBbXSwgIndheXBvaW50X3JlcXVlc3RzIjogW3sidHlwZSI6ICJGZWF0dXJlIiwgImdlb21ldHJ5IjogeyJjb29yZGluYXRlcyI6IFstNzIuNzA0NDI1LCAtNTEuNjg4NjQ1XX0sICJwcm9wZXJ0aWVzIjogeyJkYXRlVGltZSI6ICIyMDI0LTAxLTA4VDA5OjUxOjE0IiwgInNtYXJ0RGF0YVR5cGUiOiAiaW5jaWRlbnQiLCAic21hcnRGZWF0dXJlVHlwZSI6ICJ3YXlwb2ludC9uZXciLCAic21hcnRBdHRyaWJ1dGVzIjogeyJvYnNlcnZhdGlvbkdyb3VwcyI6IFt7Im9ic2VydmF0aW9ucyI6IFt7Im9ic2VydmF0aW9uVXVpZCI6ICI0NGVhZjc5OC1mYTg3LTQ4ZDktOWJhZi00MmRmZGI0YzYyMzEiLCAiY2F0ZWdvcnkiOiAiYW5pbWFscy5zaWduIiwgImF0dHJpYnV0ZXMiOiB7InNwZWNpZXMiOiAibGlvbiJ9fV19XSwgInBhdHJvbFV1aWQiOiBudWxsLCAicGF0cm9sTGVnVXVpZCI6IG51bGwsICJwYXRyb2xJZCI6IG51bGwsICJpbmNpZGVudElkIjogImd1bmRpX2V2XzQ0ZWFmNzk4LWZhODctNDhkOS05YmFmLTQyZGZkYjRjNjIzMSIsICJpbmNpZGVudFV1aWQiOiAiNDRlYWY3OTgtZmE4Ny00OGQ5LTliYWYtNDJkZmRiNGM2MjMxIiwgInRlYW0iOiBudWxsLCAib2JqZWN0aXZlIjogbnVsbCwgImNvbW1lbnQiOiAiUmVwb3J0OiBBbmltYWxzIFNpZ25cbkltcG9ydGVkOiAyMDI0LTAxLTA4VDEwOjQwOjU5LjU4MzE4MC0wMzowMCIsICJpc0FybWVkIjogbnVsbCwgInRyYW5zcG9ydFR5cGUiOiBudWxsLCAibWFuZGF0ZSI6IG51bGwsICJudW1iZXIiOiBudWxsLCAibWVtYmVycyI6IG51bGwsICJsZWFkZXIiOiBudWxsLCAiYXR0YWNobWVudHMiOiBudWxsfX19XSwgInRyYWNrX3BvaW50X3JlcXVlc3RzIjogW119",
+            # pragma: allowlist secret
             "messageId": "9155786613739819",
             "message_id": "9155786613739819",
             "publishTime": timestamp,

--- a/app/core/pubsub.py
+++ b/app/core/pubsub.py
@@ -42,10 +42,9 @@ async def send_message_to_gcp_pubsub_dispatcher(
             current_span.set_attribute("topic", topic_name)
             topic = client.topic_path(settings.GCP_PROJECT_ID, topic_name)
             # Serialize UUIDs or other complex types to string
-            message_clean = json.loads(json.dumps(message, default=str))
             attributes_clean = json.loads(json.dumps(attributes, default=str))
             ordering_key_clean = str(ordering_key)
-            messages = [pubsub.PubsubMessage(message_clean, ordering_key=ordering_key_clean, **attributes_clean)]
+            messages = [pubsub.PubsubMessage(message, ordering_key=ordering_key_clean, **attributes_clean)]
             logger.info(f"Sending observation to PubSub topic {topic_name}..")
             try:
                 response = await client.publish(

--- a/app/core/pubsub.py
+++ b/app/core/pubsub.py
@@ -44,7 +44,9 @@ async def send_message_to_gcp_pubsub_dispatcher(
             # Serialize UUIDs or other complex types to string
             attributes_clean = json.loads(json.dumps(attributes, default=str))
             ordering_key_clean = str(ordering_key)
-            messages = [pubsub.PubsubMessage(message, ordering_key=ordering_key_clean, **attributes_clean)]
+            # ToDo: enable ordering key once we update the infra to support it
+            #messages = [pubsub.PubsubMessage(message, ordering_key=ordering_key_clean, **attributes_clean)]
+            messages = [pubsub.PubsubMessage(message, **attributes_clean)]
             logger.info(f"Sending observation to PubSub topic {topic_name}..")
             try:
                 response = await client.publish(

--- a/app/core/pubsub.py
+++ b/app/core/pubsub.py
@@ -1,0 +1,107 @@
+import asyncio
+import backoff
+import aiohttp
+import json
+import logging
+from opentelemetry.trace import SpanKind
+from gcloud.aio import pubsub
+from app.core import tracing, settings
+
+
+logger = logging.getLogger(__name__)
+
+
+@backoff.on_exception(
+    backoff.expo, (aiohttp.ClientError, asyncio.TimeoutError), max_tries=20
+)
+async def send_message_to_gcp_pubsub_dispatcher(
+    message, attributes, destination, broker_config, ordering_key=""
+):
+    with tracing.tracer.start_as_current_span(  # Trace observations with Open Telemetry
+        "routing_service.send_message_to_gcp_pubsub_dispatcher",
+        kind=SpanKind.PRODUCER,
+    ) as current_span:
+        destination_id_str = str(destination.id)
+        current_span.set_attribute("destination_id", destination_id_str)
+        # Propagate OTel context in message attributes
+        tracing_context = json.dumps(
+            tracing.pubsub_instrumentation.build_context_headers(),
+            default=str,
+        )
+        attributes["tracing_context"] = tracing_context
+        timeout_settings = aiohttp.ClientTimeout(total=60.0)
+        async with aiohttp.ClientSession(
+            raise_for_status=True, timeout=timeout_settings
+        ) as session:
+            client = pubsub.PublisherClient(session=session)
+            # Get the topic name from config or use a default naming convention
+            topic_name = broker_config.get(
+                "topic",
+                f"destination-{destination_id_str}-{settings.GCP_ENVIRONMENT}",  # Try with a default name for older integrations
+            ).strip()
+            current_span.set_attribute("topic", topic_name)
+            topic = client.topic_path(settings.GCP_PROJECT_ID, topic_name)
+            # Serialize UUIDs or other complex types to string
+            message_clean = json.loads(json.dumps(message, default=str))
+            attributes_clean = json.loads(json.dumps(attributes, default=str))
+            ordering_key_clean = str(ordering_key)
+            messages = [pubsub.PubsubMessage(message_clean, ordering_key=ordering_key_clean, **attributes_clean)]
+            logger.info(f"Sending observation to PubSub topic {topic_name}..")
+            try:
+                response = await client.publish(
+                    topic, messages, timeout=int(timeout_settings.total)
+                )
+            except Exception as e:
+                error_msg = (
+                    f"Error sending observation to PubSub topic {topic_name}: {e}."
+                )
+                logger.exception(error_msg)
+                current_span.set_attribute("error", error_msg)
+                raise e
+            else:
+                logger.info(f"Observation sent successfully.")
+                logger.debug(f"GCP PubSub response: {response}")
+        current_span.add_event(
+            name="routing_service.transformed_observation_sent_to_dispatcher"
+        )
+
+
+async def send_observation_to_dead_letter_topic(transformed_observation, attributes):
+    with tracing.tracer.start_as_current_span(
+        "send_message_to_dead_letter_topic", kind=SpanKind.CLIENT
+    ) as current_span:
+        print(f"Forwarding observation to dead letter topic: {transformed_observation}")
+        # Publish to another PubSub topic
+        connect_timeout, read_timeout = settings.DEFAULT_REQUESTS_TIMEOUT
+        timeout_settings = aiohttp.ClientTimeout(
+            sock_connect=connect_timeout, sock_read=read_timeout
+        )
+        async with aiohttp.ClientSession(
+            raise_for_status=True, timeout=timeout_settings
+        ) as session:
+            client = pubsub.PublisherClient(session=session)
+            # Get the topic
+            topic_name = settings.DEAD_LETTER_TOPIC
+            current_span.set_attribute("topic", topic_name)
+            topic = client.topic_path(settings.GCP_PROJECT_ID, topic_name)
+            # Prepare the payload
+            binary_payload = json.dumps(transformed_observation, default=str).encode(
+                "utf-8"
+            )
+            messages = [pubsub.PubsubMessage(binary_payload, **attributes)]
+            logger.info(f"Sending observation to PubSub topic {topic_name}..")
+            try:  # Send to pubsub
+                response = await client.publish(topic, messages)
+            except Exception as e:
+                logger.exception(
+                    f"Error sending observation to dead letter topic {topic_name}: {e}. Please check if the topic exists or review settings."
+                )
+                raise e
+            else:
+                logger.info(f"Observation sent to the dead letter topic successfully.")
+                logger.debug(f"GCP PubSub response: {response}")
+
+        current_span.set_attribute("is_sent_to_dead_letter_queue", True)
+        current_span.add_event(
+            name="routing_service.observation_sent_to_dead_letter_queue"
+        )

--- a/app/core/utils.py
+++ b/app/core/utils.py
@@ -57,3 +57,7 @@ def is_valid_position(gundi_version: str, location):
         if gundi_version == "v1"
         else all([location.lat, location.lon])
     )
+
+
+def get_provider_key(provider):
+    return f"gundi_{provider.type.value}_{str(provider.id)}"

--- a/app/services/event_handlers.py
+++ b/app/services/event_handlers.py
@@ -118,7 +118,7 @@ async def transform_and_route_observation(observation):
                 transformer_event = build_transformer_event(transformed_observation)
                 # Publish to a GCP PubSub topic
                 pubsub_message = build_gcp_pubsub_message(
-                    payload=transformer_event.dict()
+                    payload=transformer_event.dict(exclude_none=True)
                 )
                 await send_message_to_gcp_pubsub_dispatcher(
                     message=pubsub_message,

--- a/app/services/event_handlers.py
+++ b/app/services/event_handlers.py
@@ -97,6 +97,7 @@ async def transform_and_route_observation(observation):
                     )
                     continue
 
+                # Add metadata used to dispatch the observation
                 attributes = build_transformed_message_attributes(
                     observation=observation,
                     destination=destination,
@@ -128,10 +129,7 @@ async def transform_and_route_observation(observation):
                 )
                 logger.info(
                     f"Observation {observation.gundi_id} transformed and sent to pubsub topic successfully.",
-                    extra={
-                        **attributes,
-                        "destination_id": str(destination.id),
-                    },
+                    extra=attributes
                 )
         except ReferenceDataError as e:
             error_msg = (
@@ -156,7 +154,6 @@ async def transform_and_route_observation(observation):
                 error_msg,
                 extra={
                     ExtraKeys.AttentionNeeded: True,
-                    ExtraKeys.DeadLetter: True,
                     ExtraKeys.DeviceId: get_source_id(observation, "v2"),
                     ExtraKeys.InboundIntId: get_data_provider_id(observation, "v2"),
                     ExtraKeys.StreamType: observation.observation_type,

--- a/app/services/event_handlers.py
+++ b/app/services/event_handlers.py
@@ -1,0 +1,216 @@
+import logging
+from gundi_core import schemas
+from gundi_core.events import ObservationReceived, EventReceived, EventUpdateReceived, AttachmentReceived
+from gundi_core.events.transformers import EventTransformedER, EventUpdateTransformedER, AttachmentTransformedER, \
+    ObservationTransformedER
+from opentelemetry.trace import SpanKind
+from app.core import tracing, settings
+from app.core.errors import ReferenceDataError
+from app.core.gundi import apply_source_configurations, get_connection, get_route, get_integration
+from app.core.local_logging import ExtraKeys
+from app.core.utils import Broker
+from app.core.utils import get_provider_key
+from app.core.pubsub import send_message_to_gcp_pubsub_dispatcher
+from app.services.transformers import (
+    build_transformed_message_attributes,
+    build_gcp_pubsub_message,
+    get_source_id,
+    get_data_provider_id,
+    transform_observation_v2
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+transformer_events_by_data_type = {
+    "EREvent": EventTransformedER,
+    "EREventUpdate": EventUpdateTransformedER,
+    "ERAttachment": AttachmentTransformedER,
+    "ERObservation": ObservationTransformedER,
+}
+
+
+def build_transformer_event(transformed_observation):
+    Event = transformer_events_by_data_type[type(transformed_observation).__name__]
+    return Event(
+        payload=transformed_observation
+    )
+
+
+async def transform_and_route_observation(observation):
+    with tracing.tracer.start_as_current_span(
+            "routing_service.transform_and_route_observation", kind=SpanKind.CONSUMER
+    ) as current_span:
+        try:
+            # ToDo: Implement a destination resolution algorithm considering all the routes and filters
+            connection = await get_connection(connection_id=observation.data_provider_id)
+            if not connection:
+                error = f"Connection '{observation.data_provider_id}' not found."
+                current_span.set_attribute("error", error)
+                raise ReferenceDataError(error)
+            provider = connection.provider
+            destinations = connection.destinations
+            default_route = await get_route(route_id=connection.default_route.id)
+            if not default_route:
+                error = f"Default route '{connection.default_route.id}', for provider '{observation.data_provider_id}' not found."
+                current_span.set_attribute("error", error)
+                raise ReferenceDataError(error)
+            route_configuration = default_route.configuration
+            provider_key = get_provider_key(provider)  # i.e. gundi_cellstop_abc1234..
+            current_span.set_attribute("destinations_qty", len(destinations))
+            current_span.set_attribute(
+                "destinations", str([str(d.id) for d in destinations])
+            )
+            if len(destinations) < 1:
+                current_span.add_event(
+                    name="routing_service.observation_has_no_destinations"
+                )
+                logger.warning(
+                    f"Connection {observation.data_provider_id} has no Destinations. This is a configuration error.",
+                    extra={
+                        ExtraKeys.DeviceId: observation.source_id,
+                        ExtraKeys.InboundIntId: observation.data_provider_id,
+                        ExtraKeys.StreamType: observation.observation_type,
+                        ExtraKeys.GundiVersion: "v2",
+                        ExtraKeys.GundiId: observation.gundi_id,
+                        ExtraKeys.AttentionNeeded: True,
+                    },
+                )
+
+            for destination in destinations:
+                # Get additional configuration for the destination
+                destination_integration = await get_integration(integration_id=destination.id)
+                broker_config = destination_integration.additional
+
+                # Transform the observation for the destination
+                transformed_observation = await transform_observation_v2(
+                    observation=observation,
+                    destination=destination,
+                    provider=provider,
+                    route_configuration=route_configuration,
+                )
+
+                if not transformed_observation:
+                    logger.warning(
+                        f"Observation {observation.gundi_id} could not be transformed for destination {destination.id}. Discarded.",
+                    )
+                    continue
+
+                attributes = build_transformed_message_attributes(
+                    observation=observation,
+                    destination=destination,
+                    gundi_version="v2",
+                    provider_key=provider_key,
+                )
+                logger.debug(
+                    f"Transformed observation: {repr(transformed_observation)}, attributes: {attributes}"
+                )
+
+                if broker_type := broker_config.get("broker", Broker.GCP_PUBSUB.value).strip().lower() != Broker.GCP_PUBSUB.value:
+                    current_span.set_attribute("broker", broker_type)
+                    raise ReferenceDataError(
+                        f"Broker '{broker_type}' is no longer supported. Please use `{Broker.GCP_PUBSUB.value}` instead."
+                    )
+
+                # Build system event for dispatchers
+                transformer_event = build_transformer_event(transformed_observation)
+                # Publish to a GCP PubSub topic
+                pubsub_message = build_gcp_pubsub_message(
+                    payload=transformer_event.dict()
+                )
+                await send_message_to_gcp_pubsub_dispatcher(
+                    message=pubsub_message,
+                    attributes=attributes,
+                    destination=destination,
+                    broker_config=broker_config,
+                    ordering_key=observation.gundi_id
+                )
+                logger.info(
+                    f"Observation {observation.gundi_id} transformed and sent to pubsub topic successfully.",
+                    extra={
+                        **attributes,
+                        "destination_id": str(destination.id),
+                    },
+                )
+        except ReferenceDataError as e:
+            error_msg = (
+                f"External error occurred obtaining reference data for observation: {e}",
+            )
+            logger.exception(
+                error_msg,
+                extra={
+                    ExtraKeys.AttentionNeeded: True,
+                    ExtraKeys.DeviceId: get_source_id(observation, "v2"),
+                    ExtraKeys.InboundIntId: get_data_provider_id(observation, "v2"),
+                    ExtraKeys.StreamType: observation.observation_type,
+                },
+            )
+            current_span.set_attribute("error", error_msg)
+            raise e  # Raise the exception so the message is retried later by GCP
+        except Exception as e:
+            error_msg = (
+                f"Unexpected internal exception occurred processing observation: {e}"
+            )
+            logger.exception(
+                error_msg,
+                extra={
+                    ExtraKeys.AttentionNeeded: True,
+                    ExtraKeys.DeadLetter: True,
+                    ExtraKeys.DeviceId: get_source_id(observation, "v2"),
+                    ExtraKeys.InboundIntId: get_data_provider_id(observation, "v2"),
+                    ExtraKeys.StreamType: observation.observation_type,
+                },
+            )
+            # Unexpected internal errors
+            current_span.set_attribute("error", error_msg)
+            raise e  # Raise the exception so the message is retried later by GCP
+
+
+async def handle_observation_received(event: ObservationReceived):
+    # Trace observations with Open Telemetry
+    with tracing.tracer.start_as_current_span(
+            "routing_service.handle_observation_received", kind=SpanKind.CONSUMER
+    ) as current_span:
+        current_span.set_attribute("payload", repr(event.payload))
+        await transform_and_route_observation(observation=event.payload)
+
+
+async def handle_event_received(event: EventReceived):
+    with tracing.tracer.start_as_current_span(
+            "routing_service.handle_event_received", kind=SpanKind.CONSUMER
+    ) as current_span:
+        current_span.set_attribute("payload", repr(event.payload))
+        await transform_and_route_observation(observation=event.payload)
+
+
+async def handle_event_update(event: EventUpdateReceived):
+    with tracing.tracer.start_as_current_span(
+            "routing_service.handle_event_update", kind=SpanKind.CONSUMER
+    ) as current_span:
+        event_update = event.payload
+        current_span.set_attribute("payload", repr(event.payload))
+        current_span.set_attribute("changes", str(event_update.changes))
+        await transform_and_route_observation(observation=event_update)
+
+
+async def handle_attachment_received(event: AttachmentReceived):
+    with tracing.tracer.start_as_current_span(
+            "routing_service.handle_attachment_received", kind=SpanKind.CONSUMER
+    ) as current_span:
+        current_span.set_attribute("payload", repr(event.payload))
+        await transform_and_route_observation(observation=event.payload)
+
+event_handlers = {
+    "ObservationReceived": handle_observation_received,
+    "EventReceived": handle_event_received,
+    "EventUpdateReceived": handle_event_update,
+    "AttachmentReceived": handle_attachment_received,
+}
+
+event_schemas = {
+    "ObservationReceived": ObservationReceived,
+    "EventReceived": EventReceived,
+    "EventUpdateReceived": EventUpdateReceived,
+    "AttachmentReceived": AttachmentReceived,
+}

--- a/app/services/process_messages.py
+++ b/app/services/process_messages.py
@@ -1,17 +1,14 @@
-import json
 import logging
-import aiohttp
-import asyncio
-import backoff
 from datetime import datetime, timezone
 from app.core import tracing
 from opentelemetry.trace import SpanKind
+from gundi_core import schemas
 from app.core.local_logging import ExtraKeys
 from app.core.utils import Broker
 from app.core.errors import ReferenceDataError
+from app.services.event_handlers import event_handlers, event_schemas
 from app.services.transformers import (
     extract_fields_from_message,
-    convert_observation_to_cdip_schema,
     build_gcp_pubsub_message,
     get_source_id,
     get_data_provider_id,
@@ -19,72 +16,40 @@ from app.services.transformers import (
     build_transformed_message_attributes,
 )
 from app.core.gundi import (
-    apply_source_configurations,
-    get_connection,
-    get_route,
-    get_all_outbound_configs_for_id,
-    get_integration,
+    get_all_outbound_configs_for_id, update_observation_with_device_configuration,
 )
 from app.core import settings
-from gcloud.aio import pubsub
+from app.core.pubsub import send_message_to_gcp_pubsub_dispatcher, send_observation_to_dead_letter_topic
 
 
 logger = logging.getLogger(__name__)
 
 
-@backoff.on_exception(
-    backoff.expo, (aiohttp.ClientError, asyncio.TimeoutError), max_tries=20
-)
-async def send_message_to_gcp_pubsub_dispatcher(
-    message, attributes, destination, broker_config
-):
-    with tracing.tracer.start_as_current_span(  # Trace observations with Open Telemetry
-        "routing_service.send_message_to_gcp_pubsub_dispatcher",
-        kind=SpanKind.PRODUCER,
+async def process_observation_event(raw_message, attributes):
+    with tracing.tracer.start_as_current_span(
+            "routing_service.process_observations_event", kind=SpanKind.CONSUMER
     ) as current_span:
-        destination_id_str = str(destination.id)
-        current_span.set_attribute("destination_id", destination_id_str)
-        # Propagate OTel context in message attributes
-        tracing_context = json.dumps(
-            tracing.pubsub_instrumentation.build_context_headers(),
-            default=str,
-        )
-        attributes["tracing_context"] = tracing_context
-        timeout_settings = aiohttp.ClientTimeout(total=60.0)
-        async with aiohttp.ClientSession(
-            raise_for_status=True, timeout=timeout_settings
-        ) as session:
-            client = pubsub.PublisherClient(session=session)
-            # Get the topic name from config or use a default naming convention
-            topic_name = broker_config.get(
-                "topic",
-                f"destination-{destination_id_str}-{settings.GCP_ENVIRONMENT}",  # Try with a default name for older integrations
-            ).strip()
-            current_span.set_attribute("topic", topic_name)
-            topic = client.topic_path(settings.GCP_PROJECT_ID, topic_name)
-            messages = [pubsub.PubsubMessage(message, **attributes)]
-            logger.info(f"Sending observation to PubSub topic {topic_name}..")
-            try:
-                response = await client.publish(
-                    topic, messages, timeout=int(timeout_settings.total)
-                )
-            except Exception as e:
-                error_msg = (
-                    f"Error sending observation to PubSub topic {topic_name}: {e}."
-                )
-                logger.exception(error_msg)
-                current_span.set_attribute("error", error_msg)
-                raise e
-            else:
-                logger.info(f"Observation sent successfully.")
-                logger.debug(f"GCP PubSub response: {response}")
-        current_span.add_event(
-            name="routing_service.transformed_observation_sent_to_dispatcher"
-        )
-
-
-def get_provider_key(provider):
-    return f"gundi_{provider.type.value}_{str(provider.id)}"
+        logger.debug(f"Message received: \npayload: {raw_message} \nattributes: {attributes}")
+        current_span.add_event(name="routing_service.observations_received_at_consumer")
+        event_type = raw_message.get("event_type")
+        # ToDo: Check event schema version
+        # ToDo: Discard duplicate events
+        current_span.set_attribute("system_event_type", event_type)
+        current_span.set_attribute("observation_type", str(raw_message.get("observation_type")))
+        current_span.set_attribute("message", str(raw_message))
+        current_span.set_attribute("environment", settings.TRACE_ENVIRONMENT)
+        current_span.set_attribute("service", "cdip-routing")
+        try:
+            handler = event_handlers[event_type]
+        except KeyError:
+            logger.warning(f"Event Type {event_type} not  supported. Message discarded.")
+            return
+        try:
+            schema = event_schemas[event_type]
+        except KeyError:
+            logger.warning(f"Event Schema for {event_type} not found. Message discarded.")
+        parsed_event = schema.parse_obj(raw_message)
+        return await handler(event=parsed_event)
 
 
 async def process_observation(raw_observation, attributes):
@@ -94,7 +59,6 @@ async def process_observation(raw_observation, attributes):
     it decorates it with Device-specific information fetched from
     Gundi's portal.
     """
-    # ToDo: Consider splitting this in two functions for gundi v1 and gundi v2
     # Trace observations with Open Telemetry
     with tracing.tracer.start_as_current_span(
         "routing_service.process_observation", kind=SpanKind.CONSUMER
@@ -109,31 +73,24 @@ async def process_observation(raw_observation, attributes):
             logger.debug(f"attributes: {attributes}")
             # Get the schema version to process it accordingly
             gundi_version = attributes.get("gundi_version", "v1")
-            observation = convert_observation_to_cdip_schema(
-                raw_observation, gundi_version=gundi_version
-            )
+            schema = schemas.models_by_stream_type[raw_observation.get("observation_type")]
+            observation = schema.parse_obj(raw_observation)
             observation_logging_extra = {
-                ExtraKeys.DeviceId: get_source_id(observation, gundi_version),
-                ExtraKeys.InboundIntId: get_data_provider_id(
-                    observation, gundi_version
-                ),
+                ExtraKeys.DeviceId: observation.device_id,
+                ExtraKeys.InboundIntId: observation.integration_id,
                 ExtraKeys.StreamType: observation.observation_type,
-                ExtraKeys.GundiVersion: gundi_version,
-                ExtraKeys.GundiId: observation.gundi_id
-                if gundi_version == "v2"
-                else observation.id,
-                ExtraKeys.RelatedTo: observation.related_to
-                if gundi_version == "v2"
-                else "",
+                ExtraKeys.GundiVersion: "v1",
+                ExtraKeys.GundiId: "",
+                ExtraKeys.RelatedTo: "",
             }
             logger.info(
-                "received unprocessed observation",
-                extra=observation_logging_extra,
+                f"Received unprocessed observation: {observation_logging_extra}",
+                extra=observation_logging_extra,  # FixMe: Extra is ignored by GCP
             )
         except Exception as e:
             logger.exception(
-                f"Exception occurred prior to processing observation",
-                extra={
+                f"Exception occurred prior to processing observation: \n{observation_logging_extra} \n error: {e}",
+                extra={   # FixMe: Extra is ignored by GCP
                     ExtraKeys.AttentionNeeded: True,
                     ExtraKeys.Observation: raw_observation,
                 },
@@ -142,39 +99,13 @@ async def process_observation(raw_observation, attributes):
 
         try:
             if observation:
-                # Process the observation differently according to the Gundi Version
-                await apply_source_configurations(
-                    observation=observation, gundi_version=gundi_version
+                await update_observation_with_device_configuration(observation)
+                provider = None
+                route_configuration = None
+                provider_key = None
+                destinations = await get_all_outbound_configs_for_id(
+                    observation.integration_id, observation.device_id
                 )
-                if gundi_version == "v2":
-                    # ToDo: Implement a destination resolution algorithm considering all the routes and filters
-                    connection = await get_connection(
-                        connection_id=observation.data_provider_id
-                    )
-                    if not connection:
-                        error = f"Connection '{observation.data_provider_id}' not found."
-                        current_span.set_attribute("error", error)
-                        raise ReferenceDataError(error)
-                    provider = connection.provider
-                    destinations = connection.destinations
-                    default_route = await get_route(
-                        route_id=connection.default_route.id
-                    )
-                    if not default_route:
-                        error = f"Default route '{connection.default_route.id}', for provider '{observation.data_provider_id}' not found."
-                        current_span.set_attribute("error", error)
-                        raise ReferenceDataError(error)
-                    route_configuration = default_route.configuration
-                    provider_key = get_provider_key(
-                        provider
-                    )  # i.e. gundi_cellstop_abc1234..
-                else:  # Default to v1
-                    provider = None
-                    route_configuration = None
-                    provider_key = None
-                    destinations = await get_all_outbound_configs_for_id(
-                        observation.integration_id, observation.device_id
-                    )
                 current_span.set_attribute("destinations_qty", len(destinations))
                 current_span.set_attribute(
                     "destinations", str([str(d.id) for d in destinations])
@@ -186,37 +117,23 @@ async def process_observation(raw_observation, attributes):
                     logger.warning(
                         "Updating observation with Device info, but it has no Destinations. This is a configuration error.",
                         extra={
-                            ExtraKeys.DeviceId: get_source_id(
-                                observation, gundi_version
-                            ),
-                            ExtraKeys.InboundIntId: get_data_provider_id(
-                                observation, gundi_version
-                            ),
+                            ExtraKeys.DeviceId: observation.device_id,
+                            ExtraKeys.InboundIntId: observation.integration_id,
                             ExtraKeys.StreamType: observation.observation_type,
-                            ExtraKeys.GundiVersion: gundi_version,
-                            ExtraKeys.GundiId: observation.gundi_id
-                            if gundi_version == "v2"
-                            else observation.id,
+                            ExtraKeys.GundiVersion: "v1",
+                            ExtraKeys.GundiId: "",
                             ExtraKeys.AttentionNeeded: True,
                         },
                     )
 
                 for destination in destinations:
                     # Get additional configuration for the destination
-                    if gundi_version == "v2":
-                        destination_integration = await get_integration(
-                            integration_id=destination.id
-                        )
-                        broker_config = destination_integration.additional
-                    else:
-                        broker_config = destination.additional
+                    broker_config = destination.additional
                     # Transform the observation for the destination
                     transformed_observation = (
                         await transform_observation_to_destination_schema(
                             observation=observation,
-                            destination=destination_integration
-                            if gundi_version == "v2"
-                            else destination,
+                            destination=destination,
                             provider=provider,
                             route_configuration=route_configuration,
                             gundi_version=gundi_version,
@@ -235,7 +152,7 @@ async def process_observation(raw_observation, attributes):
                     )
 
                     broker_type = (
-                        broker_config.get("broker", Broker.KAFKA.value).strip().lower()
+                        broker_config.get("broker", Broker.GCP_PUBSUB.value).strip().lower()
                     )
                     current_span.set_attribute("broker", broker_type)
                     if broker_type != Broker.GCP_PUBSUB.value:
@@ -310,47 +227,6 @@ async def process_observation(raw_observation, attributes):
             raise e  # Raise the exception so the message is retried later by GCP
 
 
-async def send_observation_to_dead_letter_topic(transformed_observation, attributes):
-    with tracing.tracer.start_as_current_span(
-        "send_message_to_dead_letter_topic", kind=SpanKind.CLIENT
-    ) as current_span:
-        print(f"Forwarding observation to dead letter topic: {transformed_observation}")
-        # Publish to another PubSub topic
-        connect_timeout, read_timeout = settings.DEFAULT_REQUESTS_TIMEOUT
-        timeout_settings = aiohttp.ClientTimeout(
-            sock_connect=connect_timeout, sock_read=read_timeout
-        )
-        async with aiohttp.ClientSession(
-            raise_for_status=True, timeout=timeout_settings
-        ) as session:
-            client = pubsub.PublisherClient(session=session)
-            # Get the topic
-            topic_name = settings.DEAD_LETTER_TOPIC
-            current_span.set_attribute("topic", topic_name)
-            topic = client.topic_path(settings.GCP_PROJECT_ID, topic_name)
-            # Prepare the payload
-            binary_payload = json.dumps(transformed_observation, default=str).encode(
-                "utf-8"
-            )
-            messages = [pubsub.PubsubMessage(binary_payload, **attributes)]
-            logger.info(f"Sending observation to PubSub topic {topic_name}..")
-            try:  # Send to pubsub
-                response = await client.publish(topic, messages)
-            except Exception as e:
-                logger.exception(
-                    f"Error sending observation to dead letter topic {topic_name}: {e}. Please check if the topic exists or review settings."
-                )
-                raise e
-            else:
-                logger.info(f"Observation sent to the dead letter topic successfully.")
-                logger.debug(f"GCP PubSub response: {response}")
-
-        current_span.set_attribute("is_sent_to_dead_letter_queue", True)
-        current_span.add_event(
-            name="routing_service.observation_sent_to_dead_letter_queue"
-        )
-
-
 def is_too_old(timestamp):
     if not timestamp:
         return False
@@ -366,7 +242,7 @@ def is_too_old(timestamp):
 async def process_request(request):
     # Extract the observation and attributes from the CloudEvent
     json_data = await request.json()
-    raw_observation, attributes = extract_fields_from_message(json_data["message"])
+    payload, attributes = extract_fields_from_message(json_data["message"])
     # Load tracing context
     tracing.pubsub_instrumentation.load_context_from_attributes(attributes)
     with tracing.tracer.start_as_current_span(
@@ -376,19 +252,23 @@ async def process_request(request):
             logger.warning(
                 f"Message discarded. The message is too old or the retry time limit has been reached."
             )
-            await send_observation_to_dead_letter_topic(raw_observation, attributes)
+            await send_observation_to_dead_letter_topic(payload, attributes)
             return {
                 "status": "discarded",
                 "reason": "Message is too old or the retry time limit has been reach",
             }
-        if (version := attributes.get("gundi_version", "v1")) not in ["v1", "v2"]:
+        if (version := attributes.get("gundi_version", "v1")) == "v1":
+            await process_observation(payload, attributes)
+        elif version == "v2":
+            await process_observation_event(payload, attributes)
+        else:
             logger.warning(
                 f"Message discarded. Version '{version}' is not supported by this dispatcher."
             )
-            await send_observation_to_dead_letter_topic(raw_observation, attributes)
+            await send_observation_to_dead_letter_topic(payload, attributes)
             return {
                 "status": "discarded",
                 "reason": f"Gundi '{version}' messages are not supported",
             }
-        await process_observation(raw_observation, attributes)
+
         return {"status": "processed"}

--- a/app/services/transformers.py
+++ b/app/services/transformers.py
@@ -1356,11 +1356,6 @@ class EREventUpdateTransformer(Transformer):
             for rule in rules:
                 rule.apply(message=er_changes)
         er_event_update = schemas.v2.EREventUpdate(
-            gundi_id=str(message.gundi_id),
-            related_to=str(message.related_to),
-            owner=str(message.owner),
-            data_provider_id=str(message.data_provider_id),
-            annotations=message.annotations,
             changes=er_changes
         )
         return er_event_update
@@ -1374,11 +1369,6 @@ class ERAttachmentTransformer(Transformer):
         self, message: schemas.v2.Attachment, rules: list = None, **kwargs
     ) -> schemas.v2.ERAttachment:
         return schemas.v2.ERAttachment(
-            gundi_id=str(message.gundi_id),
-            related_to=str(message.related_to),
-            owner=str(message.owner),
-            data_provider_id=str(message.data_provider_id),
-            annotations=message.annotations,
             file_path=message.file_path
         )
 

--- a/app/tests/test_process_observations.py
+++ b/app/tests/test_process_observations.py
@@ -19,7 +19,7 @@ async def test_process_observation_and_route_to_gcp_pubsub_dispatcher(
     )
     mocker.patch("app.core.gundi._cache_db", mock_cache)
     mocker.patch("app.core.gundi._portal", mock_gundi_client)
-    mocker.patch("app.services.process_messages.pubsub", mock_pubsub_client)
+    mocker.patch("app.core.pubsub.pubsub", mock_pubsub_client)
     await process_observation(
         raw_observation_position, raw_observation_position_attributes
     )
@@ -46,7 +46,8 @@ async def test_retry_observations_sent_to_gcp_pubsub_on_timeout(
     mocker.patch("app.core.gundi._portal", mock_gundi_client)
     # The mocked PubSub client raises an asyncio.TimeoutError in the first call, and returns success in a second call
     mocker.patch(
-        "app.services.process_messages.pubsub", mock_pubsub_client_with_timeout_once
+        "app.core.pubsub.pubsub"
+, mock_pubsub_client_with_timeout_once
     )
     await process_observation(
         raw_observation_position, raw_observation_position_attributes
@@ -81,7 +82,8 @@ async def test_retry_observations_sent_to_gcp_pubsub_on_client_error(
     mocker.patch("app.core.gundi._portal", mock_gundi_client)
     # The mocked PubSub client raises an asyncio.TimeoutError in the first call, and returns success in a second call
     mocker.patch(
-        "app.services.process_messages.pubsub",
+        "app.core.pubsub.pubsub"
+,
         mock_pubsub_client_with_client_error_once,
     )
     await process_observation(
@@ -197,7 +199,7 @@ async def test_process_observation_geoevent_and_route_to_gcp_pubsub_dispatcher(
     )
     mocker.patch("app.core.gundi._cache_db", mock_cache)
     mocker.patch("app.core.gundi._portal", mock_gundi_client)
-    mocker.patch("app.services.process_messages.pubsub", mock_pubsub_client)
+    mocker.patch("app.core.pubsub.pubsub", mock_pubsub_client)
     await process_observation(
         raw_observation_geoevent, raw_observation_geoevent_attributes
     )
@@ -222,7 +224,7 @@ async def test_process_observation_cameratrap_and_route_to_gcp_pubsub_dispatcher
     )
     mocker.patch("app.core.gundi._cache_db", mock_cache)
     mocker.patch("app.core.gundi._portal", mock_gundi_client)
-    mocker.patch("app.services.process_messages.pubsub", mock_pubsub_client)
+    mocker.patch("app.core.pubsub.pubsub", mock_pubsub_client)
     await process_observation(
         raw_observation_cameratrap, raw_observation_cameratrap_attributes
     )

--- a/app/tests/test_process_observations_v2.py
+++ b/app/tests/test_process_observations_v2.py
@@ -3,24 +3,23 @@ from app.services.process_messages import process_observation_event
 from app.core.utils import get_provider_key
 
 
-# ToDo: Finish refactoring this test
-# @pytest.mark.asyncio
-# async def test_process_observations_v2(
-#     mocker,
-#     mock_cache,
-#     mock_gundi_client_v2,
-#     mock_pubsub_client,
-#     raw_observation_v2,
-#     raw_observation_v2_attributes,
-# ):
-#     # Mock external dependencies
-#     mocker.patch("app.core.gundi._cache_db", mock_cache)
-#     mocker.patch("app.core.gundi.portal_v2", mock_gundi_client_v2)
-#     mocker.patch("app.core.pubsub.pubsub", mock_pubsub_client)
-#     await process_observation_event(raw_observation_v2, raw_observation_v2_attributes)
-#     # Check that the right methods, to publish to PuSub, were called
-#     assert mock_pubsub_client.PublisherClient.called
-#     assert mock_pubsub_client.PublisherClient.return_value.publish.called
+@pytest.mark.asyncio
+async def test_process_observations_v2(
+    mocker,
+    mock_cache,
+    mock_gundi_client_v2,
+    mock_pubsub_client,
+    raw_observation_v2,
+    raw_observation_v2_attributes,
+):
+    # Mock external dependencies
+    mocker.patch("app.core.gundi._cache_db", mock_cache)
+    mocker.patch("app.core.gundi.portal_v2", mock_gundi_client_v2)
+    mocker.patch("app.core.pubsub.pubsub", mock_pubsub_client)
+    await process_observation_event(raw_observation_v2, raw_observation_v2_attributes)
+    # Check that the right methods, to publish to PuSub, were called
+    assert mock_pubsub_client.PublisherClient.called
+    assert mock_pubsub_client.PublisherClient.return_value.publish.called
 
 
 @pytest.mark.asyncio
@@ -37,6 +36,25 @@ async def test_process_events_v2(
     mocker.patch("app.core.gundi.portal_v2", mock_gundi_client_v2)
     mocker.patch("app.core.pubsub.pubsub", mock_pubsub_client)
     await process_observation_event(raw_event_v2, raw_event_v2_attributes)
+    # Check that the right methods, to publish to PuSub, were called
+    assert mock_pubsub_client.PublisherClient.called
+    assert mock_pubsub_client.PublisherClient.return_value.publish.called
+
+
+@pytest.mark.asyncio
+async def test_process_event_update(
+    mocker,
+    mock_cache,
+    mock_gundi_client_v2,
+    mock_pubsub_client,
+    raw_event_update,
+    raw_event_update_attributes,
+):
+    # Mock external dependencies
+    mocker.patch("app.core.gundi._cache_db", mock_cache)
+    mocker.patch("app.core.gundi.portal_v2", mock_gundi_client_v2)
+    mocker.patch("app.core.pubsub.pubsub", mock_pubsub_client)
+    await process_observation_event(raw_event_update, raw_event_update_attributes)
     # Check that the right methods, to publish to PuSub, were called
     assert mock_pubsub_client.PublisherClient.called
     assert mock_pubsub_client.PublisherClient.return_value.publish.called

--- a/app/tests/test_process_observations_v2.py
+++ b/app/tests/test_process_observations_v2.py
@@ -1,5 +1,26 @@
 import pytest
-from app.services.process_messages import process_observation, get_provider_key
+from app.services.process_messages import process_observation_event
+from app.core.utils import get_provider_key
+
+
+# ToDo: Finish refactoring this test
+# @pytest.mark.asyncio
+# async def test_process_observations_v2(
+#     mocker,
+#     mock_cache,
+#     mock_gundi_client_v2,
+#     mock_pubsub_client,
+#     raw_observation_v2,
+#     raw_observation_v2_attributes,
+# ):
+#     # Mock external dependencies
+#     mocker.patch("app.core.gundi._cache_db", mock_cache)
+#     mocker.patch("app.core.gundi.portal_v2", mock_gundi_client_v2)
+#     mocker.patch("app.core.pubsub.pubsub", mock_pubsub_client)
+#     await process_observation_event(raw_observation_v2, raw_observation_v2_attributes)
+#     # Check that the right methods, to publish to PuSub, were called
+#     assert mock_pubsub_client.PublisherClient.called
+#     assert mock_pubsub_client.PublisherClient.return_value.publish.called
 
 
 @pytest.mark.asyncio
@@ -14,8 +35,8 @@ async def test_process_events_v2(
     # Mock external dependencies
     mocker.patch("app.core.gundi._cache_db", mock_cache)
     mocker.patch("app.core.gundi.portal_v2", mock_gundi_client_v2)
-    mocker.patch("app.services.process_messages.pubsub", mock_pubsub_client)
-    await process_observation(raw_event_v2, raw_event_v2_attributes)
+    mocker.patch("app.core.pubsub.pubsub", mock_pubsub_client)
+    await process_observation_event(raw_event_v2, raw_event_v2_attributes)
     # Check that the right methods, to publish to PuSub, were called
     assert mock_pubsub_client.PublisherClient.called
     assert mock_pubsub_client.PublisherClient.return_value.publish.called
@@ -33,8 +54,8 @@ async def test_process_attachments_v2(
     # Mock external dependencies
     mocker.patch("app.core.gundi._cache_db", mock_cache)
     mocker.patch("app.core.gundi.portal_v2", mock_gundi_client_v2)
-    mocker.patch("app.services.process_messages.pubsub", mock_pubsub_client)
-    await process_observation(raw_attachment_v2, raw_attachment_v2_attributes)
+    mocker.patch("app.core.pubsub.pubsub", mock_pubsub_client)
+    await process_observation_event(raw_attachment_v2, raw_attachment_v2_attributes)
     # Check that the right methods, to publish to PuSub, were called
     assert mock_pubsub_client.PublisherClient.called
     assert mock_pubsub_client.PublisherClient.return_value.publish.called

--- a/app/tests/test_process_request.py
+++ b/app/tests/test_process_request.py
@@ -5,7 +5,6 @@ from app.main import app
 api_client = TestClient(app)
 
 
-# ToDo: Finish refactoring this test
 @pytest.mark.asyncio
 async def test_process_geoevent_v1_successfully(
     mocker,

--- a/app/tests/test_process_request.py
+++ b/app/tests/test_process_request.py
@@ -18,7 +18,7 @@ async def test_process_geoevent_v1_successfully(
     # Mock external dependencies
     mocker.patch("app.core.gundi._cache_db", mock_cache)
     mocker.patch("app.core.gundi._portal", mock_gundi_client)
-    mocker.patch("app.services.process_messages.pubsub", mock_pubsub_client)
+    mocker.patch("app.core.pubsub.pubsub", mock_pubsub_client)
     response = api_client.post(
         "/",
         headers=pubsub_cloud_event_headers,

--- a/app/tests/test_transform_observations_v2.py
+++ b/app/tests/test_transform_observations_v2.py
@@ -7,18 +7,18 @@ async def test_event_type_mapping(
     mock_cache,
     mock_gundi_client_v2,
     mock_pubsub_client,
-    leopard_detected_event_v2,
+    leopard_detected_from_species_event_v2,
     destination_integration_v2_er,
     route_config_with_event_type_mappings,
     connection_v2,
 ):
     transformed_observation = await transform_observation_v2(
-        observation=leopard_detected_event_v2,
+        observation=leopard_detected_from_species_event_v2,
         destination=destination_integration_v2_er,
         provider=connection_v2.provider,
         route_configuration=route_config_with_event_type_mappings,
     )
-    assert transformed_observation["event_type"] == "leopard_sighting"
+    assert transformed_observation.event_type == "leopard_sighting"
 
 
 @pytest.mark.asyncio
@@ -39,7 +39,7 @@ async def test_event_type_mapping_default(
         route_configuration=route_config_with_event_type_mappings,
     )
     # Check that it's mapped to the default type
-    assert transformed_observation["event_type"] == "wildlife_sighting_rep"
+    assert transformed_observation.event_type == "wildlife_sighting_rep"
 
 
 @pytest.mark.asyncio
@@ -91,22 +91,13 @@ async def test_transform_observations_for_earthranger(
         route_configuration=route_config_with_no_mappings,
     )
     assert transformed_observation
-    assert (
-        transformed_observation.get("manufacturer_id")
-        == observation_object_v2.external_source_id
-    )
-    assert transformed_observation.get("source_type") == observation_object_v2.type
-    assert (
-        transformed_observation.get("subject_name") == observation_object_v2.source_name
-    )
-    assert (
-        transformed_observation.get("recorded_at") == observation_object_v2.recorded_at
-    )
-    assert transformed_observation.get("location") == {
-        "lon": observation_object_v2.location.lon,
-        "lat": observation_object_v2.location.lat,
-    }
-    assert transformed_observation.get("additional") == observation_object_v2.additional
+    assert transformed_observation.manufacturer_id == observation_object_v2.external_source_id
+    assert transformed_observation.source_type == observation_object_v2.type
+    assert transformed_observation.subject_name == observation_object_v2.source_name
+    assert transformed_observation.recorded_at == observation_object_v2.recorded_at
+    assert transformed_observation.location.longitude == observation_object_v2.location.lon
+    assert transformed_observation.location.latitude == observation_object_v2.location.lat
+    assert transformed_observation.additional == observation_object_v2.additional
 
 
 @pytest.mark.asyncio
@@ -132,12 +123,12 @@ async def test_transform_events_without_route_configuration(
     mock_cache,
     mock_gundi_client_v2,
     mock_pubsub_client,
-    unmapped_animal_detected_event_v2,
+    animals_sign_event_v2,
     destination_integration_v2_er,
     connection_v2,
 ):
     transformed_observation = await transform_observation_v2(
-        observation=unmapped_animal_detected_event_v2,
+        observation=animals_sign_event_v2,
         destination=destination_integration_v2_er,
         provider=connection_v2.provider,
         route_configuration=None,
@@ -150,20 +141,20 @@ async def test_provider_key_mapping_with_default(
     mock_cache,
     mock_gundi_client_v2,
     mock_pubsub_client,
-    unmapped_animal_detected_event_v2,
+    animals_sign_event_v2,
     destination_integration_v2_er,
     route_config_with_provider_key_mappings,
     connection_v2,
 ):
     # Test with a species that is not in the map
     transformed_observation = await transform_observation_v2(
-        observation=unmapped_animal_detected_event_v2,
+        observation=animals_sign_event_v2,
         destination=destination_integration_v2_er,
         provider=connection_v2.provider,
         route_configuration=route_config_with_provider_key_mappings,
     )
     # Check that it's mapped to the default type
-    assert transformed_observation.get("provider_key") == "mapipedia"
+    assert transformed_observation.provider_key == "mapipedia"
 
 
 @pytest.mark.asyncio
@@ -184,7 +175,7 @@ async def test_provider_key_mapping_in_observations_v2(
         route_configuration=route_config_with_provider_key_mappings,
     )
     # Check that it's mapped to the default type
-    assert transformed_observation.get("provider_key") == "mapipedia"
+    assert transformed_observation.provider_key == "mapipedia"
 
 
 @pytest.mark.asyncio
@@ -204,8 +195,8 @@ async def test_provider_key_mapping_in_events_v2(
         provider=connection_v2.provider,
         route_configuration=route_config_with_provider_key_mappings,
     )
-    # Check that it's mapped to the default type
-    assert transformed_observation.get("provider_key") == "mapipedia"
+    # Check that it's mapped to the provider key
+    assert transformed_observation.provider_key == "mapipedia"
 
 
 @pytest.mark.asyncio

--- a/app/tests/test_transform_observations_v2.py
+++ b/app/tests/test_transform_observations_v2.py
@@ -95,8 +95,8 @@ async def test_transform_observations_for_earthranger(
     assert transformed_observation.source_type == observation_object_v2.type
     assert transformed_observation.subject_name == observation_object_v2.source_name
     assert transformed_observation.recorded_at == observation_object_v2.recorded_at
-    assert transformed_observation.location.longitude == observation_object_v2.location.lon
-    assert transformed_observation.location.latitude == observation_object_v2.location.lat
+    assert transformed_observation.location.lon == observation_object_v2.location.lon
+    assert transformed_observation.location.lat == observation_object_v2.location.lat
     assert transformed_observation.additional == observation_object_v2.additional
 
 

--- a/app/tests/test_transform_observations_v2.py
+++ b/app/tests/test_transform_observations_v2.py
@@ -236,3 +236,22 @@ async def test_transform_events_for_smart(
     observation = observation_group["observations"][0]
     assert observation.get("category") == "animals.sign"
     assert observation.get("attributes") == {"ageofsign": "days", "species": "lion"}
+
+
+@pytest.mark.asyncio
+async def test_transform_event_update_with_type_mapping_for_earthranger(
+    mock_cache,
+    mock_gundi_client_v2,
+    mock_pubsub_client,
+    event_update_species_wildcat,
+    destination_integration_v2_er,
+    route_config_with_event_type_mappings,
+    connection_v2,
+):
+    transformed_observation = await transform_observation_v2(
+        observation=event_update_species_wildcat,
+        destination=destination_integration_v2_er,
+        provider=connection_v2.provider,
+        route_configuration=route_config_with_event_type_mappings,
+    )
+    assert transformed_observation.changes.get("event_type") == "wild_cat_sighting"

--- a/requirements.in
+++ b/requirements.in
@@ -13,8 +13,8 @@ packaging==23.0
 https://github.com/PADAS/er-client/releases/download/v1.2.0-alpha/earthranger_client-1.2.0-py3-none-any.whl
 https://github.com/PADAS/smartconnect-client/releases/download/v1.5.3/smartconnect_client-1.5.3-py3-none-any.whl
 gundi-client==1.0.2
-gundi-client-v2==2.3.0
-gundi-core==1.5.7
+gundi-client-v2==2.3.3
+gundi-core==1.5.8
 opentelemetry-api==1.14.0
 opentelemetry-sdk==1.14.0
 opentelemetry-exporter-gcp-trace==1.3.0

--- a/requirements.in
+++ b/requirements.in
@@ -14,7 +14,7 @@ https://github.com/PADAS/er-client/releases/download/v1.2.0-alpha/earthranger_cl
 https://github.com/PADAS/smartconnect-client/releases/download/v1.5.3/smartconnect_client-1.5.3-py3-none-any.whl
 gundi-client==1.0.2
 gundi-client-v2==2.3.0
-gundi-core==1.5.5
+gundi-core==1.5.7
 opentelemetry-api==1.14.0
 opentelemetry-sdk==1.14.0
 opentelemetry-exporter-gcp-trace==1.3.0

--- a/requirements.in
+++ b/requirements.in
@@ -14,7 +14,7 @@ https://github.com/PADAS/er-client/releases/download/v1.2.0-alpha/earthranger_cl
 https://github.com/PADAS/smartconnect-client/releases/download/v1.5.3/smartconnect_client-1.5.3-py3-none-any.whl
 gundi-client==1.0.2
 gundi-client-v2==2.3.0
-gundi-core==1.4.0
+gundi-core==1.5.4
 opentelemetry-api==1.14.0
 opentelemetry-sdk==1.14.0
 opentelemetry-exporter-gcp-trace==1.3.0

--- a/requirements.in
+++ b/requirements.in
@@ -14,7 +14,7 @@ https://github.com/PADAS/er-client/releases/download/v1.2.0-alpha/earthranger_cl
 https://github.com/PADAS/smartconnect-client/releases/download/v1.5.3/smartconnect_client-1.5.3-py3-none-any.whl
 gundi-client==1.0.2
 gundi-client-v2==2.3.0
-gundi-core==1.5.4
+gundi-core==1.5.5
 opentelemetry-api==1.14.0
 opentelemetry-sdk==1.14.0
 opentelemetry-exporter-gcp-trace==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -107,7 +107,7 @@ gundi-client==1.0.2
     # via -r requirements.in
 gundi-client-v2==2.3.0
     # via -r requirements.in
-gundi-core==1.5.5
+gundi-core==1.5.7
     # via
     #   -r requirements.in
     #   gundi-client

--- a/requirements.txt
+++ b/requirements.txt
@@ -107,7 +107,7 @@ gundi-client==1.0.2
     # via -r requirements.in
 gundi-client-v2==2.3.0
     # via -r requirements.in
-gundi-core==1.5.4
+gundi-core==1.5.5
     # via
     #   -r requirements.in
     #   gundi-client

--- a/requirements.txt
+++ b/requirements.txt
@@ -107,7 +107,7 @@ gundi-client==1.0.2
     # via -r requirements.in
 gundi-client-v2==2.3.0
     # via -r requirements.in
-gundi-core==1.4.0
+gundi-core==1.5.4
     # via
     #   -r requirements.in
     #   gundi-client

--- a/requirements.txt
+++ b/requirements.txt
@@ -105,9 +105,9 @@ grpcio-status==1.48.2
     # via google-api-core
 gundi-client==1.0.2
     # via -r requirements.in
-gundi-client-v2==2.3.0
+gundi-client-v2==2.3.3
     # via -r requirements.in
-gundi-core==1.5.7
+gundi-core==1.5.8
     # via
     #   -r requirements.in
     #   gundi-client

--- a/test_local.sh
+++ b/test_local.sh
@@ -1,0 +1,88 @@
+curl localhost:8282 \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -H "ce-id: 123451234512345" \
+  -H "ce-specversion: 1.0" \
+  -H "ce-time: 2024-07-18T17:40:00.789Z" \
+  -H "ce-type: google.cloud.pubsub.topic.v1.messagePublished" \
+  -H "ce-source: //pubsub.googleapis.com/projects/MY-PROJECT/topics/MY-TOPIC" \
+  -d '{
+      "message": {
+        "data":"eyJldmVudF9pZCI6ICIyZGZkZDc3ZS0zY2RlLTQyNjktYjJhOC1kZTAxMzc0ZDMyOTQiLCAidGltZXN0YW1wIjogIjIwMjQtMDctMjQgMTQ6MTg6NDEuOTUxMjQxKzAwOjAwIiwgInNjaGVtYV92ZXJzaW9uIjogInYxIiwgInBheWxvYWQiOiB7Imd1bmRpX2lkIjogIjJhMWUwZTZjLTMzNGYtNDJmZS05ZDQ1LTEyYzM0ZWQ0ODY2ZiIsICJvd25lciI6ICJhOTFiNDAwYi00ODJhLTQ1NDYtOGZjYi1lZTQyYjAxZGVlYjYiLCAiZGF0YV9wcm92aWRlcl9pZCI6ICJkODhhYzUyMC0yYmY2LTRlNmItYWIwOS0zOGVkMWVjNjk0N2EiLCAiYW5ub3RhdGlvbnMiOiB7fSwgInNvdXJjZV9pZCI6ICJhYzFiOWNkYy1hMTkzLTQ1MTUtYjQ0Ni1iMTc3YmNjNWYzNDIiLCAiZXh0ZXJuYWxfc291cmNlX2lkIjogImNhbWVyYTEyMyIsICJyZWNvcmRlZF9hdCI6ICIyMDI0LTA3LTI0IDE0OjE4OjEyKzAwOjAwIiwgImxvY2F0aW9uIjogeyJsYXQiOiAxMy42ODg2MzUsICJsb24iOiAxMy43ODMwNjUsICJhbHQiOiAwLjB9LCAidGl0bGUiOiAiQW5pbWFsIERldGVjdGVkIFRlc3QgRXZlbnQiLCAiZXZlbnRfdHlwZSI6ICJ3aWxkbGlmZV9zaWdodGluZ19yZXAiLCAiZXZlbnRfZGV0YWlscyI6IHsic3BlY2llcyI6ICJMaW9uIn0sICJvYnNlcnZhdGlvbl90eXBlIjogImV2In0sICJldmVudF90eXBlIjogIkV2ZW50UmVjZWl2ZWQifQ==",
+        "attributes":{
+          "gundi_version":"v2",
+          "provider_key":"gundi_traptagger_ddd0946d-15b0-4308-b93d-e0470b6d33b6",
+          "gundi_id":"6cb82182-51b2-4309-ba83-c99ed8e61ae8",
+          "related_to": "None",
+          "stream_type":"ev",
+          "source_id":"ea2d5fca-752a-4a44-b170-668d780db85e",
+          "external_source_id":"Xyz123",
+          "destination_id":"f45b1d48-46fc-414b-b1ca-7b56b87b2020",
+          "data_provider_id":"d88ac520-2bf6-4e6b-ab09-38ed1ec6947a",
+          "annotations":"{}",
+          "tracing_context":"{}"
+        }
+      },
+      "subscription": "projects/MY-PROJECT/subscriptions/MY-SUB"
+    }'
+# AttachmentReceived
+#  -d '{
+#      "message": {
+#        "data":"eyJldmVudF9pZCI6ICI5MzE5NDA0Yy1hMDJhLTQwMzgtYWQ4OC1kNzUwMmU3OGMyMDMiLCAidGltZXN0YW1wIjogIjIwMjQtMDctMjQgMjA6MTM6MzMuNjk1MDE0KzAwOjAwIiwgInNjaGVtYV92ZXJzaW9uIjogInYxIiwgInBheWxvYWQiOiB7Imd1bmRpX2lkIjogIjliZWRjMDNlLTg0MTUtNDZkYi1hYTcwLTc4MjQ5MGNkZmYzMSIsICJyZWxhdGVkX3RvIjogIjZjYjgyMTgyLTUxYjItNDMwOS1iYTgzLWM5OWVkOGU2MWFlOCIsICJvd25lciI6ICJuYSIsICJkYXRhX3Byb3ZpZGVyX2lkIjogImY4NzBlMjI4LTRhNjUtNDBmMC04ODhjLTQxYmRjMTEyNGMzYyIsICJzb3VyY2VfaWQiOiAiTm9uZSIsICJleHRlcm5hbF9zb3VyY2VfaWQiOiAiTm9uZSIsICJmaWxlX3BhdGgiOiAiYXR0YWNobWVudHMvOWJlZGMwM2UtODQxNS00NmRiLWFhNzAtNzgyNDkwY2RmZjMxX3dpbGRfZG9nLW1hbGUuc3ZnIiwgIm9ic2VydmF0aW9uX3R5cGUiOiAiYXR0In0sICJldmVudF90eXBlIjogIkF0dGFjaG1lbnRSZWNlaXZlZCJ9",
+#        "attributes":{
+#          "gundi_version":"v2",
+#          "provider_key":"gundi_traptagger_ddd0946d-15b0-4308-b93d-e0470b6d33b6",
+#          "gundi_id":"9bedc03e-8415-46db-aa70-782490cdff31",
+#          "related_to": "6cb82182-51b2-4309-ba83-c99ed8e61ae8",
+#          "stream_type":"att",
+#          "source_id":"ea2d5fca-752a-4a44-b170-668d780db85e",
+#          "external_source_id":"Xyz123",
+#          "destination_id":"f45b1d48-46fc-414b-b1ca-7b56b87b2020",
+#          "data_provider_id":"d88ac520-2bf6-4e6b-ab09-38ed1ec6947a",
+#          "annotations":"{}",
+#          "tracing_context":"{}"
+#        }
+#      },
+#      "subscription": "projects/MY-PROJECT/subscriptions/MY-SUB"
+#    }'
+# EventReceived
+#  -d '{
+#      "message": {
+#        "data":"eyJldmVudF9pZCI6ICIyZGZkZDc3ZS0zY2RlLTQyNjktYjJhOC1kZTAxMzc0ZDMyOTQiLCAidGltZXN0YW1wIjogIjIwMjQtMDctMjQgMTQ6MTg6NDEuOTUxMjQxKzAwOjAwIiwgInNjaGVtYV92ZXJzaW9uIjogInYxIiwgInBheWxvYWQiOiB7Imd1bmRpX2lkIjogIjJhMWUwZTZjLTMzNGYtNDJmZS05ZDQ1LTEyYzM0ZWQ0ODY2ZiIsICJvd25lciI6ICJhOTFiNDAwYi00ODJhLTQ1NDYtOGZjYi1lZTQyYjAxZGVlYjYiLCAiZGF0YV9wcm92aWRlcl9pZCI6ICJkODhhYzUyMC0yYmY2LTRlNmItYWIwOS0zOGVkMWVjNjk0N2EiLCAiYW5ub3RhdGlvbnMiOiB7fSwgInNvdXJjZV9pZCI6ICJhYzFiOWNkYy1hMTkzLTQ1MTUtYjQ0Ni1iMTc3YmNjNWYzNDIiLCAiZXh0ZXJuYWxfc291cmNlX2lkIjogImNhbWVyYTEyMyIsICJyZWNvcmRlZF9hdCI6ICIyMDI0LTA3LTI0IDE0OjE4OjEyKzAwOjAwIiwgImxvY2F0aW9uIjogeyJsYXQiOiAxMy42ODg2MzUsICJsb24iOiAxMy43ODMwNjUsICJhbHQiOiAwLjB9LCAidGl0bGUiOiAiQW5pbWFsIERldGVjdGVkIFRlc3QgRXZlbnQiLCAiZXZlbnRfdHlwZSI6ICJ3aWxkbGlmZV9zaWdodGluZ19yZXAiLCAiZXZlbnRfZGV0YWlscyI6IHsic3BlY2llcyI6ICJMaW9uIn0sICJvYnNlcnZhdGlvbl90eXBlIjogImV2In0sICJldmVudF90eXBlIjogIkV2ZW50UmVjZWl2ZWQifQ==",
+#        "attributes":{
+#          "gundi_version":"v2",
+#          "provider_key":"gundi_traptagger_ddd0946d-15b0-4308-b93d-e0470b6d33b6",
+#          "gundi_id":"6cb82182-51b2-4309-ba83-c99ed8e61ae8",
+#          "related_to": "None",
+#          "stream_type":"ev",
+#          "source_id":"ea2d5fca-752a-4a44-b170-668d780db85e",
+#          "external_source_id":"Xyz123",
+#          "destination_id":"f45b1d48-46fc-414b-b1ca-7b56b87b2020",
+#          "data_provider_id":"d88ac520-2bf6-4e6b-ab09-38ed1ec6947a",
+#          "annotations":"{}",
+#          "tracing_context":"{}"
+#        }
+#      },
+#      "subscription": "projects/MY-PROJECT/subscriptions/MY-SUB"
+#    }'
+# EventUpdateReceived ?
+#    -d '{
+#      "message": {
+#        "data":"eyJldmVudF9pZCI6ICJiMTFjN2VlYS03ODMwLTRkMDctODdjOS1iNzdiMDc1ZjEyY2MiLCAidGltZXN0YW1wIjogIjIwMjQtMDctMTkgMTQ6MTk6MDUuNDAzMjc4KzAwOjAwIiwgInNjaGVtYV92ZXJzaW9uIjogInYxIiwgInBheWxvYWQiOiB7Imd1bmRpX2lkIjogIjc4ODY3YTc0LTY3ZjAtNGI1Ni04ZTQ0LTEyNWFlNjY0MDhmZiIsICJyZWxhdGVkX3RvIjogIk5vbmUiLCAib3duZXIiOiAiYTkxYjQwMGItNDgyYS00NTQ2LThmY2ItZWU0MmIwMWRlZWI2IiwgImRhdGFfcHJvdmlkZXJfaWQiOiAiZjg3MGUyMjgtNGE2NS00MGYwLTg4OGMtNDFiZGMxMTI0YzNjIiwgImFubm90YXRpb25zIjogbnVsbCwgInNvdXJjZV9pZCI6ICJhYzFiOWNkYy1hMTkzLTQ1MTUtYjQ0Ni1iMTc3YmNjNWYzNDIiLCAiZXh0ZXJuYWxfc291cmNlX2lkIjogImNhbWVyYTEyMyIsICJjaGFuZ2VzIjogeyJldmVudF9kZXRhaWxzIjogeyJzcGVjaWVzIjogIndpbGRjYXQifX0sICJvYnNlcnZhdGlvbl90eXBlIjogImV2dSJ9LCAiZXZlbnRfdHlwZSI6ICJFdmVudFVwZGF0ZVJlY2VpdmVkIn0=",
+#        "attributes":{
+#          "gundi_version":"v2",
+#          "provider_key":"d88ac520-2bf6-4e6b-ab09-38ed1ec6947a",
+#          "gundi_id":"189d3730-c6de-4bb7-974e-7bc410e2f4a2",
+#          "related_to": "None",
+#          "stream_type":"evu",
+#          "source_id":"ea2d5fca-752a-4a44-b170-668d780db85e",
+#          "external_source_id":"Xyz123",
+#          "destination_id":"a9aa0990-2674-4ff4-8ba2-f9b9a613d7c0",
+#          "data_provider_id":"d88ac520-2bf6-4e6b-ab09-38ed1ec6947a",
+#          "annotations":"{}",
+#          "tracing_context":"{}"
+#        }
+#      },
+#      "subscription": "projects/MY-PROJECT/subscriptions/MY-SUB"
+#    }'
+


### PR DESCRIPTION
### What does this PR do?
- Adds support for processing event updates for EarthRanger
    - Updates `gundi-core` to get new pydantic models related to event updates and system events (EDA)
    - Refactors the business logic responsible for processing messages v2 to use the new pydantic models
    - Refactor transformers to support event updates
    - Save the last update delivered time in gundi traces
    - Save source in gundi traces
    - Consume events coming from dispatchers related to event updates and generate activity logs 
- Adds test coverage for event updates
- Refactor pre-existent tests as needed

**Notice**: This includes breaking changes so it need to be deployed together with [GUNDI-2963](https://allenai.atlassian.net/browse/GUNDI-2963) and [GUNDI-2968](https://allenai.atlassian.net/browse/GUNDI-2968)

### Relevant link(s)
[GUNDI-2964](https://allenai.atlassian.net/browse/GUNDI-2964)

[GUNDI-2963]: https://allenai.atlassian.net/browse/GUNDI-2963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GUNDI-2968]: https://allenai.atlassian.net/browse/GUNDI-2968?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GUNDI-2964]: https://allenai.atlassian.net/browse/GUNDI-2964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ