### PR TITLE
GUNDI-3307: Improve error handling cache access errors

### DIFF
--- a/app/conftest.py
+++ b/app/conftest.py
@@ -6,8 +6,8 @@ import uuid
 import asyncio
 import gundi_core.schemas.v2 as schemas_v2
 import gundi_core.schemas.v1 as schemas_v1
-from aiohttp.client_reqrep import ConnectionKey
 from pydantic.types import UUID
+from redis import exceptions as redis_exceptions
 
 
 def async_return(result):
@@ -29,6 +29,23 @@ def mock_cache(mocker):
     mock_cache.__aenter__.return_value = mock_cache
     mock_cache.__aexit__.return_value = None
     mock_cache.pipeline.return_value = mock_cache
+    return mock_cache
+
+
+@pytest.fixture
+def mock_cache_with_cached_connection(mocker, connection_v2):
+    mock_cache = mocker.MagicMock()
+    cached_data = connection_v2.json()
+    mock_cache.get.return_value = async_return(cached_data)
+    return mock_cache
+
+
+@pytest.fixture
+def mock_cache_with_connection_error(mocker):
+    mock_cache = mocker.MagicMock()
+    mock_cache.get.side_effect = redis_exceptions.ConnectionError(
+        "Error while reading from 172.22.161.3:6379 : (104, 'Connection reset by peer')"
+    )
     return mock_cache
 
 

--- a/app/tests/test_get_connection_details.py
+++ b/app/tests/test_get_connection_details.py
@@ -1,0 +1,49 @@
+import pytest
+from app.core.gundi import get_connection
+from gundi_core import schemas
+
+
+@pytest.mark.asyncio
+async def test_get_connection_from_cache(
+    mocker, mock_cache_with_cached_connection, connection_v2, mock_gundi_client_v2
+):
+    # Mock external dependencies
+    mocker.patch("app.core.gundi._cache_db", mock_cache_with_cached_connection)  # empty cache
+    mocker.patch("app.core.gundi.portal_v2", mock_gundi_client_v2)
+    connection = await get_connection(
+        connection_id=str(connection_v2.id)
+    )
+    assert mock_cache_with_cached_connection.get.called
+    assert not mock_gundi_client_v2.get_connection_details.called
+    assert connection == connection_v2
+
+
+@pytest.mark.asyncio
+async def test_get_connection_from_gundi_on_cache_miss(
+    mocker, mock_cache, connection_v2, mock_gundi_client_v2
+):
+    # Mock external dependencies
+    mocker.patch("app.core.gundi._cache_db", mock_cache)  # empty cache
+    mocker.patch("app.core.gundi.portal_v2", mock_gundi_client_v2)
+    connection = await get_connection(
+        connection_id=str(connection_v2.id)
+    )
+    assert mock_cache.get.called
+    mock_gundi_client_v2.get_connection_details.assert_called_once_with(integration_id=str(connection_v2.id))
+    assert connection == connection_v2
+
+
+@pytest.mark.asyncio
+async def test_get_connection_from_gundi_on_cache_error(
+    mocker, mock_cache_with_connection_error, connection_v2, mock_gundi_client_v2
+):
+    # Mock external dependencies
+    mocker.patch("app.core.gundi._cache_db", mock_cache_with_connection_error)  # empty cache
+    mocker.patch("app.core.gundi.portal_v2", mock_gundi_client_v2)
+    connection = await get_connection(
+        connection_id=str(connection_v2.id)
+    )
+    assert mock_cache_with_connection_error.get.called
+    mock_gundi_client_v2.get_connection_details.assert_called_once_with(integration_id=str(connection_v2.id))
+    assert connection == connection_v2
+

--- a/app/tests/test_get_connection_details.py
+++ b/app/tests/test_get_connection_details.py
@@ -23,7 +23,7 @@ async def test_get_connection_from_gundi_on_cache_miss(
     mocker, mock_cache, connection_v2, mock_gundi_client_v2
 ):
     # Mock external dependencies
-    mocker.patch("app.core.gundi._cache_db", mock_cache)  # empty cache
+    mocker.patch("app.core.gundi._cache_db", mock_cache)  # faulty cache
     mocker.patch("app.core.gundi.portal_v2", mock_gundi_client_v2)
     connection = await get_connection(
         connection_id=str(connection_v2.id)


### PR DESCRIPTION
### What does this PR do?
- Makes improvements in the error handling logic while retrieving connection details. If there's a network issue or other internal errors while trying to read from our Redis cache, then get details from the gundi api.
- Adds test coverage for the bugfixes

### Relevant link(s)
[GUNDI-3307](https://allenai.atlassian.net/browse/GUNDI-3307)

[GUNDI-3307]: https://allenai.atlassian.net/browse/GUNDI-3307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ