### PR TITLE
GUNDI-3297: Event Updates for SMART

### DIFF
--- a/app/conftest.py
+++ b/app/conftest.py
@@ -1469,7 +1469,7 @@ def animals_sign_event_update_v2():
         source_id="afa0d606-c143-4705-955d-68133645db6d",
         external_source_id="Xyz123",
         changes={
-            "title": "Leopard Sign",
+            "title": "Puma Sign",
             "recorded_at": "2024-08-05 13:27:10+00:00",
             "location": {
                 "lat": 13.123456,
@@ -1480,6 +1480,23 @@ def animals_sign_event_update_v2():
                 "species": "puma",
                 "ageofsign": "weeks",
             },
+        },
+        observation_type="evu",
+    )
+
+
+@pytest.fixture
+def animals_sign_event_update_title_v2():
+    return schemas_v2.EventUpdate(
+        gundi_id="c1b46dc1-b144-556c-c87a-2ef373ca04b0",
+        related_to=None,
+        owner="e2d1b0fc-69fe-408b-afc5-7f54872730c0",
+        data_provider_id="ddd0946d-15b0-4308-b93d-e0470b6d33b6",
+        annotations={},
+        source_id="afa0d606-c143-4705-955d-68133645db6d",
+        external_source_id="Xyz123",
+        changes={
+            "title": "Leopard Sign"
         },
         observation_type="evu",
     )

--- a/app/conftest.py
+++ b/app/conftest.py
@@ -1470,9 +1470,15 @@ def animals_sign_event_update_v2():
         external_source_id="Xyz123",
         changes={
             "title": "Leopard Sign",
+            "recorded_at": "2024-08-05 13:27:10+00:00",
+            "location": {
+                "lat": 13.123456,
+                "lon": 13.123456
+            },
+            "event_type": "animals_sign",  # Event type and details must be changed together in SMART
             "event_details": {
-                "species": "leopard",
-                "ageofsign": "weeks"
+                "species": "puma",
+                "ageofsign": "weeks",
             },
         },
         observation_type="evu",

--- a/app/conftest.py
+++ b/app/conftest.py
@@ -1304,6 +1304,27 @@ def leopard_detected_from_species_event_v2():
 
 
 @pytest.fixture
+def event_v2_with_empty_event_details():
+    return schemas_v2.Event(
+        gundi_id="b9b46dc1-e033-447d-a99b-0fe373ca04c9",
+        related_to="None",
+        owner="e2d1b0fc-69fe-408b-afc5-7f54872730c0",
+        data_provider_id="ddd0946d-15b0-4308-b93d-e0470b6d33b6",
+        annotations={},
+        source_id="afa0d606-c143-4705-955d-68133645db6d",
+        external_source_id="Xyz123",
+        recorded_at=datetime.datetime(2023, 7, 4, 21, 38, tzinfo=datetime.timezone.utc),
+        location=schemas_v2.Location(
+            lat=-51.667875, lon=-72.71195, alt=1800.0, hdop=None, vdop=None
+        ),
+        title="Animal Detected",
+        event_type="wildlife_sighting_rep",
+        event_details={},
+        geometry={},
+        observation_type="ev",
+    )
+
+@pytest.fixture
 def event_update_species_wildcat():
     return schemas_v2.EventUpdate(
         gundi_id="78867a74-67f0-4b56-8e44-125ae66408ff",

--- a/app/conftest.py
+++ b/app/conftest.py
@@ -1503,6 +1503,66 @@ def animals_sign_event_update_title_v2():
 
 
 @pytest.fixture
+def animals_sign_event_update_location_v2():
+    return schemas_v2.EventUpdate(
+        gundi_id="c1b46dc1-b144-556c-c87a-2ef373ca04b0",
+        related_to=None,
+        owner="e2d1b0fc-69fe-408b-afc5-7f54872730c0",
+        data_provider_id="ddd0946d-15b0-4308-b93d-e0470b6d33b6",
+        annotations={},
+        source_id="afa0d606-c143-4705-955d-68133645db6d",
+        external_source_id="Xyz123",
+        changes={
+            "location": {
+                "lat": 13.123457,
+                "lon": 13.123457
+            }
+        },
+        observation_type="evu",
+    )
+
+
+@pytest.fixture
+def animals_sign_event_update_details_v2():
+    return schemas_v2.EventUpdate(
+        gundi_id="c1b46dc1-b144-556c-c87a-2ef373ca04b0",
+        related_to=None,
+        owner="e2d1b0fc-69fe-408b-afc5-7f54872730c0",
+        data_provider_id="ddd0946d-15b0-4308-b93d-e0470b6d33b6",
+        annotations={},
+        source_id="afa0d606-c143-4705-955d-68133645db6d",
+        external_source_id="Xyz123",
+        changes={
+            "event_type": "animals_sign",  # Event type and details must be changed together in SMART
+            "event_details": {
+                "species": "leopard"
+            },
+        },
+        observation_type="evu",
+    )
+
+
+@pytest.fixture
+def animals_sign_event_update_details_without_event_type_v2():
+    return schemas_v2.EventUpdate(
+        gundi_id="c1b46dc1-b144-556c-c87a-2ef373ca04b0",
+        related_to=None,
+        owner="e2d1b0fc-69fe-408b-afc5-7f54872730c0",
+        data_provider_id="ddd0946d-15b0-4308-b93d-e0470b6d33b6",
+        annotations={},
+        source_id="afa0d606-c143-4705-955d-68133645db6d",
+        external_source_id="Xyz123",
+        changes={
+            # Event type intentionally left out
+            "event_details": {
+                "species": "leopard"
+            },
+        },
+        observation_type="evu",
+    )
+
+
+@pytest.fixture
 def integration_type_er():
     return schemas_v2.ConnectionIntegrationType(
         id="45c66a61-71e4-4664-a7f2-30d465f87aa6",

--- a/app/conftest.py
+++ b/app/conftest.py
@@ -1450,14 +1450,32 @@ def animals_sign_event_v2():
         title="Animal Sign",
         event_type="animals_sign",
         event_details={
-            "site_name": "MM Spot",
             "species": "lion",
-            "tags": ["adult", "male"],
-            "animal_count": 2,
             "ageofsign": "days",
         },
         geometry={},
         observation_type="ev",
+    )
+
+
+@pytest.fixture
+def animals_sign_event_update_v2():
+    return schemas_v2.EventUpdate(
+        gundi_id="c1b46dc1-b144-556c-c87a-2ef373ca04b0",
+        related_to=None,
+        owner="e2d1b0fc-69fe-408b-afc5-7f54872730c0",
+        data_provider_id="ddd0946d-15b0-4308-b93d-e0470b6d33b6",
+        annotations={},
+        source_id="afa0d606-c143-4705-955d-68133645db6d",
+        external_source_id="Xyz123",
+        changes={
+            "title": "Leopard Sign",
+            "event_details": {
+                "species": "leopard",
+                "ageofsign": "weeks"
+            },
+        },
+        observation_type="evu",
     )
 
 

--- a/app/services/event_handlers.py
+++ b/app/services/event_handlers.py
@@ -1,12 +1,11 @@
 import logging
-from gundi_core import schemas
 from gundi_core.events import ObservationReceived, EventReceived, EventUpdateReceived, AttachmentReceived
 from gundi_core.events.transformers import EventTransformedER, EventUpdateTransformedER, AttachmentTransformedER, \
-    ObservationTransformedER
+    ObservationTransformedER, EventTransformedSMART, EventUpdateTransformedSMART
 from opentelemetry.trace import SpanKind
-from app.core import tracing, settings
+from app.core import tracing
 from app.core.errors import ReferenceDataError
-from app.core.gundi import apply_source_configurations, get_connection, get_route, get_integration
+from app.core.gundi import get_connection, get_route, get_integration
 from app.core.local_logging import ExtraKeys
 from app.core.utils import Broker
 from app.core.utils import get_provider_key
@@ -28,6 +27,8 @@ transformer_events_by_data_type = {
     "EREventUpdate": EventUpdateTransformedER,
     "ERAttachment": AttachmentTransformedER,
     "ERObservation": ObservationTransformedER,
+    "SMARTCompositeRequest": EventTransformedSMART,
+    "SMARTUpdateRequest": EventUpdateTransformedSMART
 }
 
 
@@ -86,7 +87,7 @@ async def transform_and_route_observation(observation):
                 # Transform the observation for the destination
                 transformed_observation = await transform_observation_v2(
                     observation=observation,
-                    destination=destination,
+                    destination=destination_integration,
                     provider=provider,
                     route_configuration=route_configuration,
                 )

--- a/app/services/transformers.py
+++ b/app/services/transformers.py
@@ -1282,7 +1282,6 @@ class SMARTTransformerV2(Transformer, ABC):
         )
         return smart_request
 
-
     async def event_update_to_waypoint_observation_update(
             self,
             *,
@@ -1291,9 +1290,6 @@ class SMARTTransformerV2(Transformer, ABC):
         observation_uuid = str(event_update.gundi_id)
         smart_feature_type = "waypoint/observation"
         smart_data_type = "incident"
-        smart_attributes = {
-            "observationUuid": observation_uuid,
-        }
         changes = event_update.changes
 
         if "event_type" not in changes or "event_details" not in changes:

--- a/app/services/transformers.py
+++ b/app/services/transformers.py
@@ -1402,7 +1402,8 @@ class FieldMappingRule(TransformationRule):
             return
 
         source_value = self._extract_value(message=message, source=self.source)
-        if source_value is None:
+        if not source_value:
+            logger.warning(f"Field Mappings: Couldn't find a valid value for '{self.source}'. Value:'{source_value}'")
             return
 
         if not self.map:

--- a/app/services/transformers.py
+++ b/app/services/transformers.py
@@ -1364,7 +1364,7 @@ class SmartEventUpdateTransformerV2(SMARTTransformerV2):
             # Update properties in Incident
             incident_update = await self.event_update_to_waypoint_update(event_update=message)
             waypoint_requests.append(incident_update)
-        if "event_type" or "event_details" in message.changes:
+        if "event_type" in message.changes or "event_details" in message.changes:
             # Update attributes in related Observation
             observation_update = await self.event_update_to_waypoint_observation_update(event_update=message)
             waypoint_requests.append(observation_update)

--- a/app/tests/test_transform_observations_v2.py
+++ b/app/tests/test_transform_observations_v2.py
@@ -219,23 +219,24 @@ async def test_transform_events_for_smart(
         route_configuration=None,
     )
     assert transformed_observation
-    assert transformed_observation.get("ca_uuid") == smart_ca_uuid
-    assert len(transformed_observation.get("waypoint_requests", [])) == 1
-    waypoint = transformed_observation.get("waypoint_requests")[0]
-    assert waypoint.get("geometry", {}).get("coordinates", []) == [
-        animals_sign_event_v2.location.lon,
-        animals_sign_event_v2.location.lat,
-    ]
-    properties = waypoint.get("properties", {})
-    assert properties.get("smartDataType") == "incident"
-    assert properties.get("smartFeatureType") == "waypoint/new"
-    attributes = properties.get("smartAttributes", {})
-    assert len(attributes.get("observationGroups", [])) == 1
-    observation_group = attributes["observationGroups"][0]
-    assert len(observation_group.get("observations", [])) == 1
-    observation = observation_group["observations"][0]
-    assert observation.get("category") == "animals.sign"
-    assert observation.get("attributes") == {"ageofsign": "days", "species": "lion"}
+    assert transformed_observation.ca_uuid == smart_ca_uuid
+    assert len(transformed_observation.waypoint_requests) == 1
+    waypoint = transformed_observation.waypoint_requests[0]
+    location = waypoint.geometry.coordinates
+    assert location
+    assert location == [animals_sign_event_v2.location.lon, animals_sign_event_v2.location.lat]
+    properties = waypoint.properties
+    assert properties
+    assert properties.smartDataType == "incident"
+    assert properties.smartFeatureType == "waypoint/new"
+    attributes = properties.smartAttributes
+    assert attributes
+    assert len(attributes.observationGroups) == 1
+    observation_group = attributes.observationGroups[0]
+    assert len(observation_group.observations) == 1
+    observation = observation_group.observations[0]
+    assert observation.category == "animals.sign"
+    assert observation.attributes == {"ageofsign": "days", "species": "lion"}
 
 
 @pytest.mark.asyncio

--- a/app/tests/test_transform_observations_v2.py
+++ b/app/tests/test_transform_observations_v2.py
@@ -48,6 +48,26 @@ async def test_event_type_mapping_default(
 
 
 @pytest.mark.asyncio
+async def test_event_type_mapping_with_empty_event_details(
+    mock_cache,
+    mock_gundi_client_v2,
+    mock_pubsub_client,
+    event_v2_with_empty_event_details,
+    destination_integration_v2_er,
+    route_config_with_event_type_mappings,
+    connection_v2,
+):
+    transformed_observation = await transform_observation_v2(
+        observation=event_v2_with_empty_event_details,
+        destination=destination_integration_v2_er,
+        provider=connection_v2.provider,
+        route_configuration=route_config_with_event_type_mappings,
+    )
+    # If event_details is empty, expect the event_type to be the same as the original one
+    assert transformed_observation.event_type == event_v2_with_empty_event_details.event_type
+
+
+@pytest.mark.asyncio
 async def test_movebank_transform_observation(
     mock_cache,
     mock_gundi_client_v2,

--- a/requirements.in
+++ b/requirements.in
@@ -14,7 +14,7 @@ https://github.com/PADAS/er-client/releases/download/v1.2.0-alpha/earthranger_cl
 https://github.com/PADAS/smartconnect-client/releases/download/v1.5.3/smartconnect_client-1.5.3-py3-none-any.whl
 gundi-client==1.0.2
 gundi-client-v2==2.3.3
-gundi-core==1.5.8
+gundi-core==1.5.9
 opentelemetry-api==1.14.0
 opentelemetry-sdk==1.14.0
 opentelemetry-exporter-gcp-trace==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -107,7 +107,7 @@ gundi-client==1.0.2
     # via -r requirements.in
 gundi-client-v2==2.3.3
     # via -r requirements.in
-gundi-core==1.5.8
+gundi-core==1.5.9
     # via
     #   -r requirements.in
     #   gundi-client

--- a/test_local.sh
+++ b/test_local.sh
@@ -8,16 +8,16 @@ curl localhost:8282 \
   -H "ce-source: //pubsub.googleapis.com/projects/MY-PROJECT/topics/MY-TOPIC" \
   -d '{
       "message": {
-        "data":"eyJldmVudF9pZCI6ICIyZGZkZDc3ZS0zY2RlLTQyNjktYjJhOC1kZTAxMzc0ZDMyOTQiLCAidGltZXN0YW1wIjogIjIwMjQtMDctMjQgMTQ6MTg6NDEuOTUxMjQxKzAwOjAwIiwgInNjaGVtYV92ZXJzaW9uIjogInYxIiwgInBheWxvYWQiOiB7Imd1bmRpX2lkIjogIjJhMWUwZTZjLTMzNGYtNDJmZS05ZDQ1LTEyYzM0ZWQ0ODY2ZiIsICJvd25lciI6ICJhOTFiNDAwYi00ODJhLTQ1NDYtOGZjYi1lZTQyYjAxZGVlYjYiLCAiZGF0YV9wcm92aWRlcl9pZCI6ICJkODhhYzUyMC0yYmY2LTRlNmItYWIwOS0zOGVkMWVjNjk0N2EiLCAiYW5ub3RhdGlvbnMiOiB7fSwgInNvdXJjZV9pZCI6ICJhYzFiOWNkYy1hMTkzLTQ1MTUtYjQ0Ni1iMTc3YmNjNWYzNDIiLCAiZXh0ZXJuYWxfc291cmNlX2lkIjogImNhbWVyYTEyMyIsICJyZWNvcmRlZF9hdCI6ICIyMDI0LTA3LTI0IDE0OjE4OjEyKzAwOjAwIiwgImxvY2F0aW9uIjogeyJsYXQiOiAxMy42ODg2MzUsICJsb24iOiAxMy43ODMwNjUsICJhbHQiOiAwLjB9LCAidGl0bGUiOiAiQW5pbWFsIERldGVjdGVkIFRlc3QgRXZlbnQiLCAiZXZlbnRfdHlwZSI6ICJ3aWxkbGlmZV9zaWdodGluZ19yZXAiLCAiZXZlbnRfZGV0YWlscyI6IHsic3BlY2llcyI6ICJMaW9uIn0sICJvYnNlcnZhdGlvbl90eXBlIjogImV2In0sICJldmVudF90eXBlIjogIkV2ZW50UmVjZWl2ZWQifQ==",
+        "data":"eyJldmVudF9pZCI6ICJjMTQxMmZiZi0xNTcwLTQ0YjAtOGE3ZC00MTFlZGUzMDFmMzciLCAidGltZXN0YW1wIjogIjIwMjQtMDgtMDIgMTE6MTg6MDQuNzIyNTI4KzAwOjAwIiwgInNjaGVtYV92ZXJzaW9uIjogInYxIiwgInBheWxvYWQiOiB7Imd1bmRpX2lkIjogIjU0NmI5MjdiLTU3OGMtNDUwNC05OWNlLWE0Mjg5NTI4NDk0MSIsICJyZWxhdGVkX3RvIjogIk5vbmUiLCAib3duZXIiOiAiYTkxYjQwMGItNDgyYS00NTQ2LThmY2ItZWU0MmIwMWRlZWI2IiwgImRhdGFfcHJvdmlkZXJfaWQiOiAiZDg4YWM1MjAtMmJmNi00ZTZiLWFiMDktMzhlZDFlYzY5NDdhIiwgInNvdXJjZV9pZCI6ICIyOTY2OWIxNy1jODg4LTRjNmQtODdiNS1kOGI5ZTE0ZTM0MmQiLCAiZXh0ZXJuYWxfc291cmNlX2lkIjogImRlZmF1bHQtc291cmNlIiwgImNoYW5nZXMiOiB7InRpdGxlIjogIkFuaW1hbHMgMDIgRWRpdGVkIChUZXN0IE1hcmlhbm8pIiwgInJlY29yZGVkX2F0IjogIjIwMjQtMDgtMDIgMTA6NDY6MTArMDA6MDAiLCAibG9jYXRpb24iOiB7ImxhdCI6IDEzLjEyMzQ1NiwgImxvbiI6IDEzLjEyMzQ1Nn0sICJldmVudF90eXBlIjogImFuaW1hbHMiLCAiZXZlbnRfZGV0YWlscyI6IHsidGFyZ2V0c3BlY2llcyI6ICJyZXB0aWxlcy5weXRob25zcHAiLCAid2lsZGxpZmVvYnNlcnZhdGlvbnR5cGUiOiAiZGlyZWN0b2JzZXJ2YXRpb24iLCAiYWdlb2ZzaWduYW5pbWFsIjogImZyZXNoIiwgIm51bWJlcm9mYW5pbWFsIjogMn19LCAib2JzZXJ2YXRpb25fdHlwZSI6ICJldnUifSwgImV2ZW50X3R5cGUiOiAiRXZlbnRVcGRhdGVSZWNlaXZlZCJ9",
         "attributes":{
           "gundi_version":"v2",
           "provider_key":"gundi_traptagger_ddd0946d-15b0-4308-b93d-e0470b6d33b6",
-          "gundi_id":"6cb82182-51b2-4309-ba83-c99ed8e61ae8",
+          "gundi_id":"546b927b-578c-4504-99ce-a42895284941",
           "related_to": "None",
-          "stream_type":"ev",
+          "stream_type":"evu",
           "source_id":"ea2d5fca-752a-4a44-b170-668d780db85e",
           "external_source_id":"Xyz123",
-          "destination_id":"f45b1d48-46fc-414b-b1ca-7b56b87b2020",
+          "destination_id":"b42c9205-5228-49e0-a75b-ebe5b6a9f78e",
           "data_provider_id":"d88ac520-2bf6-4e6b-ab09-38ed1ec6947a",
           "annotations":"{}",
           "tracing_context":"{}"
@@ -45,7 +45,7 @@ curl localhost:8282 \
 #      },
 #      "subscription": "projects/MY-PROJECT/subscriptions/MY-SUB"
 #    }'
-# EventReceived
+# EventReceived for ER
 #  -d '{
 #      "message": {
 #        "data":"eyJldmVudF9pZCI6ICIyZGZkZDc3ZS0zY2RlLTQyNjktYjJhOC1kZTAxMzc0ZDMyOTQiLCAidGltZXN0YW1wIjogIjIwMjQtMDctMjQgMTQ6MTg6NDEuOTUxMjQxKzAwOjAwIiwgInNjaGVtYV92ZXJzaW9uIjogInYxIiwgInBheWxvYWQiOiB7Imd1bmRpX2lkIjogIjJhMWUwZTZjLTMzNGYtNDJmZS05ZDQ1LTEyYzM0ZWQ0ODY2ZiIsICJvd25lciI6ICJhOTFiNDAwYi00ODJhLTQ1NDYtOGZjYi1lZTQyYjAxZGVlYjYiLCAiZGF0YV9wcm92aWRlcl9pZCI6ICJkODhhYzUyMC0yYmY2LTRlNmItYWIwOS0zOGVkMWVjNjk0N2EiLCAiYW5ub3RhdGlvbnMiOiB7fSwgInNvdXJjZV9pZCI6ICJhYzFiOWNkYy1hMTkzLTQ1MTUtYjQ0Ni1iMTc3YmNjNWYzNDIiLCAiZXh0ZXJuYWxfc291cmNlX2lkIjogImNhbWVyYTEyMyIsICJyZWNvcmRlZF9hdCI6ICIyMDI0LTA3LTI0IDE0OjE4OjEyKzAwOjAwIiwgImxvY2F0aW9uIjogeyJsYXQiOiAxMy42ODg2MzUsICJsb24iOiAxMy43ODMwNjUsICJhbHQiOiAwLjB9LCAidGl0bGUiOiAiQW5pbWFsIERldGVjdGVkIFRlc3QgRXZlbnQiLCAiZXZlbnRfdHlwZSI6ICJ3aWxkbGlmZV9zaWdodGluZ19yZXAiLCAiZXZlbnRfZGV0YWlscyI6IHsic3BlY2llcyI6ICJMaW9uIn0sICJvYnNlcnZhdGlvbl90eXBlIjogImV2In0sICJldmVudF90eXBlIjogIkV2ZW50UmVjZWl2ZWQifQ==",
@@ -65,7 +65,27 @@ curl localhost:8282 \
 #      },
 #      "subscription": "projects/MY-PROJECT/subscriptions/MY-SUB"
 #    }'
-# EventUpdateReceived ?
+# EventReceived for SMART
+#  -d '{
+#      "message": {
+#        "data":"eyJldmVudF9pZCI6ICIwYTM1OGQ5YS0wZTMwLTQzZDItYTY1Ni04MjFhZDc2MDZmNWEiLCAidGltZXN0YW1wIjogIjIwMjQtMDgtMDIgMTA6NDY6NDEuODAwODI1KzAwOjAwIiwgInNjaGVtYV92ZXJzaW9uIjogInYxIiwgInBheWxvYWQiOiB7Imd1bmRpX2lkIjogIjU0NmI5MjdiLTU3OGMtNDUwNC05OWNlLWE0Mjg5NTI4NDk0MSIsICJvd25lciI6ICJhOTFiNDAwYi00ODJhLTQ1NDYtOGZjYi1lZTQyYjAxZGVlYjYiLCAiZGF0YV9wcm92aWRlcl9pZCI6ICJkODhhYzUyMC0yYmY2LTRlNmItYWIwOS0zOGVkMWVjNjk0N2EiLCAiYW5ub3RhdGlvbnMiOiB7fSwgInNvdXJjZV9pZCI6ICIyOTY2OWIxNy1jODg4LTRjNmQtODdiNS1kOGI5ZTE0ZTM0MmQiLCAiZXh0ZXJuYWxfc291cmNlX2lkIjogImRlZmF1bHQtc291cmNlIiwgInJlY29yZGVkX2F0IjogIjIwMjQtMDgtMDIgMTA6NDY6MTArMDA6MDAiLCAibG9jYXRpb24iOiB7ImxhdCI6IDEzLjY4ODYzNCwgImxvbiI6IDEzLjc4MzA2NywgImFsdCI6IDAuMH0sICJ0aXRsZSI6ICJBbmltYWxzIDAyIChUZXN0IE1hcmlhbm8pIiwgImV2ZW50X3R5cGUiOiAiYW5pbWFscyIsICJldmVudF9kZXRhaWxzIjogeyJ0YXJnZXRzcGVjaWVzIjogInJlcHRpbGVzLnB5dGhvbnNwcCIsICJ3aWxkbGlmZW9ic2VydmF0aW9udHlwZSI6ICJkaXJlY3RvYnNlcnZhdGlvbiIsICJhZ2VvZnNpZ25hbmltYWwiOiAiZnJlc2giLCAibnVtYmVyb2ZhbmltYWwiOiAxfSwgIm9ic2VydmF0aW9uX3R5cGUiOiAiZXYifSwgImV2ZW50X3R5cGUiOiAiRXZlbnRSZWNlaXZlZCJ9",
+#        "attributes":{
+#          "gundi_version":"v2",
+#          "provider_key":"gundi_traptagger_ddd0946d-15b0-4308-b93d-e0470b6d33b6",
+#          "gundi_id":"546b927b-578c-4504-99ce-a42895284941",
+#          "related_to": "None",
+#          "stream_type":"ev",
+#          "source_id":"ea2d5fca-752a-4a44-b170-668d780db85e",
+#          "external_source_id":"Xyz123",
+#          "destination_id":"b42c9205-5228-49e0-a75b-ebe5b6a9f78e",
+#          "data_provider_id":"d88ac520-2bf6-4e6b-ab09-38ed1ec6947a",
+#          "annotations":"{}",
+#          "tracing_context":"{}"
+#        }
+#      },
+#      "subscription": "projects/MY-PROJECT/subscriptions/MY-SUB"
+#    }'
+# EventUpdateReceived for ER
 #    -d '{
 #      "message": {
 #        "data":"eyJldmVudF9pZCI6ICJiMTFjN2VlYS03ODMwLTRkMDctODdjOS1iNzdiMDc1ZjEyY2MiLCAidGltZXN0YW1wIjogIjIwMjQtMDctMTkgMTQ6MTk6MDUuNDAzMjc4KzAwOjAwIiwgInNjaGVtYV92ZXJzaW9uIjogInYxIiwgInBheWxvYWQiOiB7Imd1bmRpX2lkIjogIjc4ODY3YTc0LTY3ZjAtNGI1Ni04ZTQ0LTEyNWFlNjY0MDhmZiIsICJyZWxhdGVkX3RvIjogIk5vbmUiLCAib3duZXIiOiAiYTkxYjQwMGItNDgyYS00NTQ2LThmY2ItZWU0MmIwMWRlZWI2IiwgImRhdGFfcHJvdmlkZXJfaWQiOiAiZjg3MGUyMjgtNGE2NS00MGYwLTg4OGMtNDFiZGMxMTI0YzNjIiwgImFubm90YXRpb25zIjogbnVsbCwgInNvdXJjZV9pZCI6ICJhYzFiOWNkYy1hMTkzLTQ1MTUtYjQ0Ni1iMTc3YmNjNWYzNDIiLCAiZXh0ZXJuYWxfc291cmNlX2lkIjogImNhbWVyYTEyMyIsICJjaGFuZ2VzIjogeyJldmVudF9kZXRhaWxzIjogeyJzcGVjaWVzIjogIndpbGRjYXQifX0sICJvYnNlcnZhdGlvbl90eXBlIjogImV2dSJ9LCAiZXZlbnRfdHlwZSI6ICJFdmVudFVwZGF0ZVJlY2VpdmVkIn0=",
@@ -85,4 +105,83 @@ curl localhost:8282 \
 #      },
 #      "subscription": "projects/MY-PROJECT/subscriptions/MY-SUB"
 #    }'
-
+# EventUpdateReceived for SMART
+#  -d '{
+#      "message": {
+#        "data":"eyJldmVudF9pZCI6ICJjMTQxMmZiZi0xNTcwLTQ0YjAtOGE3ZC00MTFlZGUzMDFmMzciLCAidGltZXN0YW1wIjogIjIwMjQtMDgtMDIgMTE6MTg6MDQuNzIyNTI4KzAwOjAwIiwgInNjaGVtYV92ZXJzaW9uIjogInYxIiwgInBheWxvYWQiOiB7Imd1bmRpX2lkIjogIjU0NmI5MjdiLTU3OGMtNDUwNC05OWNlLWE0Mjg5NTI4NDk0MSIsICJyZWxhdGVkX3RvIjogIk5vbmUiLCAib3duZXIiOiAiYTkxYjQwMGItNDgyYS00NTQ2LThmY2ItZWU0MmIwMWRlZWI2IiwgImRhdGFfcHJvdmlkZXJfaWQiOiAiZDg4YWM1MjAtMmJmNi00ZTZiLWFiMDktMzhlZDFlYzY5NDdhIiwgInNvdXJjZV9pZCI6ICIyOTY2OWIxNy1jODg4LTRjNmQtODdiNS1kOGI5ZTE0ZTM0MmQiLCAiZXh0ZXJuYWxfc291cmNlX2lkIjogImRlZmF1bHQtc291cmNlIiwgImNoYW5nZXMiOiB7InRpdGxlIjogIkFuaW1hbHMgMDIgRWRpdGVkIChUZXN0IE1hcmlhbm8pIiwgInJlY29yZGVkX2F0IjogIjIwMjQtMDgtMDIgMTA6NDY6MTArMDA6MDAiLCAibG9jYXRpb24iOiB7ImxhdCI6IDEzLjEyMzQ1NiwgImxvbiI6IDEzLjEyMzQ1Nn0sICJldmVudF90eXBlIjogImFuaW1hbHMiLCAiZXZlbnRfZGV0YWlscyI6IHsidGFyZ2V0c3BlY2llcyI6ICJyZXB0aWxlcy5weXRob25zcHAiLCAid2lsZGxpZmVvYnNlcnZhdGlvbnR5cGUiOiAiZGlyZWN0b2JzZXJ2YXRpb24iLCAiYWdlb2ZzaWduYW5pbWFsIjogImZyZXNoIiwgIm51bWJlcm9mYW5pbWFsIjogMn19LCAib2JzZXJ2YXRpb25fdHlwZSI6ICJldnUifSwgImV2ZW50X3R5cGUiOiAiRXZlbnRVcGRhdGVSZWNlaXZlZCJ9",
+#        "attributes":{
+#          "gundi_version":"v2",
+#          "provider_key":"gundi_traptagger_ddd0946d-15b0-4308-b93d-e0470b6d33b6",
+#          "gundi_id":"546b927b-578c-4504-99ce-a42895284941",
+#          "related_to": "None",
+#          "stream_type":"evu",
+#          "source_id":"ea2d5fca-752a-4a44-b170-668d780db85e",
+#          "external_source_id":"Xyz123",
+#          "destination_id":"b42c9205-5228-49e0-a75b-ebe5b6a9f78e",
+#          "data_provider_id":"d88ac520-2bf6-4e6b-ab09-38ed1ec6947a",
+#          "annotations":"{}",
+#          "tracing_context":"{}"
+#        }
+#      },
+#      "subscription": "projects/MY-PROJECT/subscriptions/MY-SUB"
+#    }'
+# EventUpdateReceived for SMART - lat only (invalid)
+#  -d '{
+#      "message": {
+#        "data":"eyJldmVudF9pZCI6ICJjMTQxMmZiZi0xNTcwLTQ0YjAtOGE3ZC00MTFlZGUzMDFmMzciLCAidGltZXN0YW1wIjogIjIwMjQtMDgtMDIgMTE6MTg6MDQuNzIyNTI4KzAwOjAwIiwgInNjaGVtYV92ZXJzaW9uIjogInYxIiwgInBheWxvYWQiOiB7Imd1bmRpX2lkIjogIjU0NmI5MjdiLTU3OGMtNDUwNC05OWNlLWE0Mjg5NTI4NDk0MSIsICJyZWxhdGVkX3RvIjogIk5vbmUiLCAib3duZXIiOiAiYTkxYjQwMGItNDgyYS00NTQ2LThmY2ItZWU0MmIwMWRlZWI2IiwgImRhdGFfcHJvdmlkZXJfaWQiOiAiZDg4YWM1MjAtMmJmNi00ZTZiLWFiMDktMzhlZDFlYzY5NDdhIiwgInNvdXJjZV9pZCI6ICIyOTY2OWIxNy1jODg4LTRjNmQtODdiNS1kOGI5ZTE0ZTM0MmQiLCAiZXh0ZXJuYWxfc291cmNlX2lkIjogImRlZmF1bHQtc291cmNlIiwgImNoYW5nZXMiOiB7InRpdGxlIjogIkFuaW1hbHMgMDIgRWRpdGVkIChUZXN0IE1hcmlhbm8pIiwgInJlY29yZGVkX2F0IjogIjIwMjQtMDgtMDIgMTA6NDY6MTArMDA6MDAiLCAibG9jYXRpb24iOiB7ImxhdCI6IDEzLjEyMzQ1Nn0sICJldmVudF90eXBlIjogImFuaW1hbHMiLCAiZXZlbnRfZGV0YWlscyI6IHsidGFyZ2V0c3BlY2llcyI6ICJyZXB0aWxlcy5weXRob25zcHAiLCAid2lsZGxpZmVvYnNlcnZhdGlvbnR5cGUiOiAiZGlyZWN0b2JzZXJ2YXRpb24iLCAiYWdlb2ZzaWduYW5pbWFsIjogImZyZXNoIiwgIm51bWJlcm9mYW5pbWFsIjogMn19LCAib2JzZXJ2YXRpb25fdHlwZSI6ICJldnUifSwgImV2ZW50X3R5cGUiOiAiRXZlbnRVcGRhdGVSZWNlaXZlZCJ9",
+#        "attributes":{
+#          "gundi_version":"v2",
+#          "provider_key":"gundi_traptagger_ddd0946d-15b0-4308-b93d-e0470b6d33b6",
+#          "gundi_id":"546b927b-578c-4504-99ce-a42895284941",
+#          "related_to": "None",
+#          "stream_type":"evu",
+#          "source_id":"ea2d5fca-752a-4a44-b170-668d780db85e",
+#          "external_source_id":"Xyz123",
+#          "destination_id":"b42c9205-5228-49e0-a75b-ebe5b6a9f78e",
+#          "data_provider_id":"d88ac520-2bf6-4e6b-ab09-38ed1ec6947a",
+#          "annotations":"{}",
+#          "tracing_context":"{}"
+#        }
+#      },
+#      "subscription": "projects/MY-PROJECT/subscriptions/MY-SUB"
+#    }'
+# EventUpdateReceived for SMART - not location (valid)
+#  -d '{
+#      "message": {
+#        "data":"eyJldmVudF9pZCI6ICJjMTQxMmZiZi0xNTcwLTQ0YjAtOGE3ZC00MTFlZGUzMDFmMzciLCAidGltZXN0YW1wIjogIjIwMjQtMDgtMDIgMTE6MTg6MDQuNzIyNTI4KzAwOjAwIiwgInNjaGVtYV92ZXJzaW9uIjogInYxIiwgInBheWxvYWQiOiB7Imd1bmRpX2lkIjogIjU0NmI5MjdiLTU3OGMtNDUwNC05OWNlLWE0Mjg5NTI4NDk0MSIsICJyZWxhdGVkX3RvIjogIk5vbmUiLCAib3duZXIiOiAiYTkxYjQwMGItNDgyYS00NTQ2LThmY2ItZWU0MmIwMWRlZWI2IiwgImRhdGFfcHJvdmlkZXJfaWQiOiAiZDg4YWM1MjAtMmJmNi00ZTZiLWFiMDktMzhlZDFlYzY5NDdhIiwgInNvdXJjZV9pZCI6ICIyOTY2OWIxNy1jODg4LTRjNmQtODdiNS1kOGI5ZTE0ZTM0MmQiLCAiZXh0ZXJuYWxfc291cmNlX2lkIjogImRlZmF1bHQtc291cmNlIiwgImNoYW5nZXMiOiB7InRpdGxlIjogIkFuaW1hbHMgMTAgRWRpdGVkIE9ic3YgKFRlc3QgTWFyaWFubykiLCAicmVjb3JkZWRfYXQiOiAiMjAyNC0wOC0wMiAxMDo0NjoxMCswMDowMCIsICJldmVudF90eXBlIjogImFuaW1hbHMiLCAiZXZlbnRfZGV0YWlscyI6IHsidGFyZ2V0c3BlY2llcyI6ICJyZXB0aWxlcy5weXRob25zcHAiLCAid2lsZGxpZmVvYnNlcnZhdGlvbnR5cGUiOiAiZGlyZWN0b2JzZXJ2YXRpb24iLCAiYWdlb2ZzaWduYW5pbWFsIjogImZyZXNoIiwgIm51bWJlcm9mYW5pbWFsIjogNX19LCAib2JzZXJ2YXRpb25fdHlwZSI6ICJldnUifSwgImV2ZW50X3R5cGUiOiAiRXZlbnRVcGRhdGVSZWNlaXZlZCJ9",
+#        "attributes":{
+#          "gundi_version":"v2",
+#          "provider_key":"gundi_traptagger_ddd0946d-15b0-4308-b93d-e0470b6d33b6",
+#          "gundi_id":"546b927b-578c-4504-99ce-a42895284941",
+#          "related_to": "None",
+#          "stream_type":"evu",
+#          "source_id":"ea2d5fca-752a-4a44-b170-668d780db85e",
+#          "external_source_id":"Xyz123",
+#          "destination_id":"b42c9205-5228-49e0-a75b-ebe5b6a9f78e",
+#          "data_provider_id":"d88ac520-2bf6-4e6b-ab09-38ed1ec6947a",
+#          "annotations":"{}",
+#          "tracing_context":"{}"
+#        }
+#      },
+#      "subscription": "projects/MY-PROJECT/subscriptions/MY-SUB"
+#    }'
+# EventUpdateReceived for SMART - update title only (valid)
+#  -d '{
+#      "message": {
+#        "data":"eyJldmVudF9pZCI6ICJjMTQxMmZiZi0xNTcwLTQ0YjAtOGE3ZC00MTFlZGUzMDFmMzciLCAidGltZXN0YW1wIjogIjIwMjQtMDgtMDIgMTE6MTg6MDQuNzIyNTI4KzAwOjAwIiwgInNjaGVtYV92ZXJzaW9uIjogInYxIiwgInBheWxvYWQiOiB7Imd1bmRpX2lkIjogIjU0NmI5MjdiLTU3OGMtNDUwNC05OWNlLWE0Mjg5NTI4NDk0MSIsICJyZWxhdGVkX3RvIjogIk5vbmUiLCAib3duZXIiOiAiYTkxYjQwMGItNDgyYS00NTQ2LThmY2ItZWU0MmIwMWRlZWI2IiwgImRhdGFfcHJvdmlkZXJfaWQiOiAiZDg4YWM1MjAtMmJmNi00ZTZiLWFiMDktMzhlZDFlYzY5NDdhIiwgInNvdXJjZV9pZCI6ICIyOTY2OWIxNy1jODg4LTRjNmQtODdiNS1kOGI5ZTE0ZTM0MmQiLCAiZXh0ZXJuYWxfc291cmNlX2lkIjogImRlZmF1bHQtc291cmNlIiwgImNoYW5nZXMiOiB7InRpdGxlIjogIkFuaW1hbHMgMTAgRWRpdGVkIHRpdGxlIChUZXN0IE1hcmlhbm8pIn0sICJvYnNlcnZhdGlvbl90eXBlIjogImV2dSJ9LCAiZXZlbnRfdHlwZSI6ICJFdmVudFVwZGF0ZVJlY2VpdmVkIn0=",
+#        "attributes":{
+#          "gundi_version":"v2",
+#          "provider_key":"gundi_traptagger_ddd0946d-15b0-4308-b93d-e0470b6d33b6",
+#          "gundi_id":"546b927b-578c-4504-99ce-a42895284941",
+#          "related_to": "None",
+#          "stream_type":"evu",
+#          "source_id":"ea2d5fca-752a-4a44-b170-668d780db85e",
+#          "external_source_id":"Xyz123",
+#          "destination_id":"b42c9205-5228-49e0-a75b-ebe5b6a9f78e",
+#          "data_provider_id":"d88ac520-2bf6-4e6b-ab09-38ed1ec6947a",
+#          "annotations":"{}",
+#          "tracing_context":"{}"
+#        }
+#      },
+#      "subscription": "projects/MY-PROJECT/subscriptions/MY-SUB"
+#    }'


### PR DESCRIPTION
### What does this PR do?
- Adds support for processing event updates for SMART
    - Updates gundi-core to get new pydantic models related to event updates and system events (EDA)  
    - Add a SMART transformer to support event updates       
- Adds test coverage for event updates
- Refactor pre-existent tests as needed
- Adds samples in our local testing script for SMART
- Allow disabling tracing by env var
- Fix issues in field mappings when event_details is empty

Notice: This includes breaking changes so it needs to be deployed together with [GUNDI-2966](https://allenai.atlassian.net/browse/GUNDI-2966)

### Relevant link(s)
[GUNDI-3297](https://allenai.atlassian.net/browse/GUNDI-3297)



[GUNDI-2966]: https://allenai.atlassian.net/browse/GUNDI-2966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GUNDI-3297]: https://allenai.atlassian.net/browse/GUNDI-3297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ