### PR TITLE
Hotfix smart errors

### DIFF
--- a/app/conftest.py
+++ b/app/conftest.py
@@ -8,6 +8,7 @@ import gundi_core.schemas.v2 as schemas_v2
 import gundi_core.schemas.v1 as schemas_v1
 from aiohttp.client_reqrep import ConnectionKey
 from pydantic.types import UUID
+from smartconnect import SMARTClientException
 
 
 def async_return(result):
@@ -82,9 +83,29 @@ def mock_smart_async_client(mocker, smart_ca_data_model, smart_cm_data_models):
 
 
 @pytest.fixture
+def mock_smart_async_client_with_server_error(mocker, smart_ca_data_model, smart_cm_data_models):
+    mock_client = mocker.MagicMock()
+    mock_client.get_incident.side_effect = SMARTClientException
+    mock_client.get_patrol.return_value = async_return(None)
+    mock_client.get_configurable_models.return_value = async_return(
+        smart_cm_data_models
+    )
+    mock_client.get_data_model.return_value = async_return(smart_ca_data_model)
+    mock_client.post_smart_request.return_value = async_return({"status": "success"})
+    return mock_client
+
+
+@pytest.fixture
 def mock_smart_async_client_class(mocker, mock_smart_async_client):
     mock_smart_async_client_class = mocker.MagicMock()
     mock_smart_async_client_class.return_value = mock_smart_async_client
+    return mock_smart_async_client_class
+
+
+@pytest.fixture
+def mock_smart_async_client_class_with_server_error(mocker, mock_smart_async_client_with_server_error):
+    mock_smart_async_client_class = mocker.MagicMock()
+    mock_smart_async_client_class.return_value = mock_smart_async_client_with_server_error
     return mock_smart_async_client_class
 
 
@@ -357,6 +378,30 @@ def raw_observation_geoevent():
         "additional": None,
         "title": "Rainfall",
         "event_type": "rainfall_rep",
+        "event_details": {"amount_mm": 6, "height_m": 3},
+        "geometry": None,
+        "observation_type": "ge",
+    }
+
+
+@pytest.fixture
+def raw_observation_geoevent_with_valid_uuid():
+    return {
+        "id": "088a191a-bcf3-471b-9e7d-6ba8bc71be9e",
+        "owner": "na",
+        "integration_id": "36485b4f-88cd-49c4-a723-0ddff1f580c4",
+        "device_id": "003",
+        "recorded_at": "2023-07-05 09:16:02-03:00",
+        "location": {
+            "x": -55.784992,
+            "y": 20.806785,
+            "z": 0.0,
+            "hdop": None,
+            "vdop": None,
+        },
+        "additional": None,
+        "title": "Rainfall",
+        "event_type": "f61b0c60-c863-44d7-adc6-d9b49b389e69_rainfall_rep",
         "event_details": {"amount_mm": 6, "height_m": 3},
         "geometry": None,
         "observation_type": "ge",

--- a/app/conftest.py
+++ b/app/conftest.py
@@ -383,6 +383,29 @@ def raw_observation_geoevent():
         "observation_type": "ge",
     }
 
+@pytest.fixture
+def raw_observation_geoevent_for_smart():
+    return {
+        "id": None,
+        "owner": "na",
+        "integration_id": "36485b4f-88cd-49c4-a723-0ddff1f580c4",
+        "device_id": "survey_one",
+        "recorded_at": "2024-08-16 15:01:00-07:00",
+        "location": {
+            "x": -71.04190,
+            "y": 34.490285,
+            "z": 0.0,
+            "hdop": None,
+            "vdop": None,
+        },
+        "additional": None,
+        "title": "Anthropogenic Disturbance",
+        "event_type": "humanactivity_humansign",
+        "event_details": {"typeofhumansign": "footprints", 
+                          "ageofsign": "10 days"},
+        "geometry": None,
+        "observation_type": "ge",
+    }
 
 @pytest.fixture
 def raw_observation_geoevent_with_valid_uuid():
@@ -842,6 +865,9 @@ def smart_outbound_configuration_gcp_pubsub():
                 "broker": "gcp_pubsub",
                 "topic": "smart-dispatcher-xyz-topic",
                 "version": "7.5.7",
+                "ca_uuids": [
+                    "b48f15a7-dd87-4fb0-af42-a6a7d893705f"
+                ],
             },
         }
     )

--- a/app/core/utils.py
+++ b/app/core/utils.py
@@ -37,8 +37,13 @@ def create_cache_key(hashable_string):
 
 
 def is_uuid(*, id_str: str):
+
+    if type(id_str) is UUID:
+        return True
+
     if type(id_str) is not str:
         return False
+
     try:
         uuid_obj = UUID(id_str)
         return True

--- a/app/core/utils.py
+++ b/app/core/utils.py
@@ -37,6 +37,8 @@ def create_cache_key(hashable_string):
 
 
 def is_uuid(*, id_str: str):
+    if type(id_str) is not str:
+        return False
     try:
         uuid_obj = UUID(id_str)
         return True

--- a/app/services/process_messages.py
+++ b/app/services/process_messages.py
@@ -211,19 +211,29 @@ async def process_observation(raw_observation, attributes):
                     else:
                         broker_config = destination.additional
                     # Transform the observation for the destination
-                    transformed_observation = (
-                        await transform_observation_to_destination_schema(
-                            observation=observation,
-                            destination=destination_integration
-                            if gundi_version == "v2"
-                            else destination,
-                            provider=provider,
-                            route_configuration=route_configuration,
-                            gundi_version=gundi_version,
+                    try:
+                        transformed_observation = (
+                            await transform_observation_to_destination_schema(
+                                observation=observation,
+                                destination=destination_integration
+                                if gundi_version == "v2"
+                                else destination,
+                                provider=provider,
+                                route_configuration=route_configuration,
+                                gundi_version=gundi_version,
+                            )
                         )
-                    )
+                    except Exception as e:
+                        error_msg = (
+                            f"Error transforming observation. Sending to dead-letter. {type(e)}: {e}"
+                        )
+                        logger.exception(error_msg)
+                        await send_observation_to_dead_letter_topic(raw_observation, attributes)
+                        current_span.set_attribute("error", error_msg)
+
                     if not transformed_observation:
                         continue
+
                     attributes = build_transformed_message_attributes(
                         observation=observation,
                         destination=destination,

--- a/app/services/process_messages.py
+++ b/app/services/process_messages.py
@@ -212,8 +212,7 @@ async def process_observation(raw_observation, attributes):
                         broker_config = destination.additional
                     # Transform the observation for the destination
                     try:
-                        transformed_observation = (
-                            await transform_observation_to_destination_schema(
+                        transformed_observation = await transform_observation_to_destination_schema(
                                 observation=observation,
                                 destination=destination_integration
                                 if gundi_version == "v2"
@@ -222,7 +221,6 @@ async def process_observation(raw_observation, attributes):
                                 route_configuration=route_configuration,
                                 gundi_version=gundi_version,
                             )
-                        )
                     except Exception as e:
                         error_msg = (
                             f"Error transforming observation. Sending to dead-letter. {type(e)}: {e}"
@@ -230,6 +228,7 @@ async def process_observation(raw_observation, attributes):
                         logger.exception(error_msg)
                         await send_observation_to_dead_letter_topic(raw_observation, attributes)
                         current_span.set_attribute("error", error_msg)
+                        continue  # Skip to the next destination
 
                     if not transformed_observation:
                         continue

--- a/app/services/transformers.py
+++ b/app/services/transformers.py
@@ -1,6 +1,8 @@
 import json
 import base64
 import logging
+
+import backoff
 import pytz
 import pathlib
 import uuid
@@ -1539,6 +1541,7 @@ def get_data_provider_id(observation, gundi_version="v1"):
     )
 
 
+@backoff.on_exception(backoff.expo, Exception, max_tries=3)
 async def transform_observation_to_destination_schema(
     *,
     observation,

--- a/app/services/transformers.py
+++ b/app/services/transformers.py
@@ -563,9 +563,15 @@ class SmartEventTransformer(SMARTTransformer, Transformer):
     async def transform(self, item) -> dict:
         waypoint_requests = []
         if self._version and version.parse(self._version) >= version.parse("7.5"):
-            smart_response = await self.smartconnect_client.get_incident(
-                incident_uuid=item.id
-            )
+            # Avoid querying with blank or invalid uuids
+            if item.id and is_uuid(id_str=item.id):
+                smart_response = await self.smartconnect_client.get_incident(
+                    incident_uuid=item.id
+                )
+            else:
+                smart_response = None
+
+            # New incident
             if not smart_response:
                 incident = await self.event_to_incident(
                     event=item, smart_feature_type="waypoint/new"

--- a/app/services/transformers.py
+++ b/app/services/transformers.py
@@ -204,7 +204,7 @@ class SMARTTransformer:
             # no passed in value assumes only 1 CA is mapped
             ca_uuids = self._config.additional.get("ca_uuids", None)
             # if not exactly one CA mapped raise Exception
-            self.ca_uuid = ca_uuids[0] if len(ca_uuids) == 1 else None
+            self.ca_uuid = ca_uuids[0] if ca_uuids else None
         if not self.ca_uuid:
             raise IndeterminableCAException(
                 "Unable to determine CA uuid for observation"
@@ -1048,6 +1048,7 @@ class SMARTTransformerV2(Transformer, ABC):
         Favor finding a match in the Config CA Datamodel, then CA Datamodel.
         """
 
+        ca_uuid, search_for = get_ca_uuid_for_event(event=event)
         
         search_for = event.event_type.replace("_", ".")
         configurable_models = await self.get_configurable_models()

--- a/app/services/transformers.py
+++ b/app/services/transformers.py
@@ -564,9 +564,9 @@ class SmartEventTransformer(SMARTTransformer, Transformer):
         waypoint_requests = []
         if self._version and version.parse(self._version) >= version.parse("7.5"):
             # Avoid querying with blank or invalid uuids
-            if item.id and is_uuid(id_str=item.id):
+            if item.id and is_uuid(id_str=str(item.id)):
                 smart_response = await self.smartconnect_client.get_incident(
-                    incident_uuid=item.id
+                    incident_uuid=str(item.id)
                 )
             else:
                 smart_response = None
@@ -1547,7 +1547,7 @@ def get_data_provider_id(observation, gundi_version="v1"):
     )
 
 
-@backoff.on_exception(backoff.expo, Exception, max_tries=3)
+@backoff.on_exception(backoff.expo, (Exception, ), max_tries=3)
 async def transform_observation_to_destination_schema(
     *,
     observation,

--- a/app/tests/test_process_observations.py
+++ b/app/tests/test_process_observations.py
@@ -304,6 +304,6 @@ async def test_process_event_doesnt_call_smart_with_invalid_uuid(
     )
 
     # Check that we don't make extra requests to smart
-    assert not mock_smart_async_client_class.retrurn_value.get_incident.called
+    assert not mock_smart_async_client_class.return_value.get_incident.called
     # Check that message was Not sent to teh dead letter
     assert not mock_send_observation_to_dead_letter_topic.called

--- a/app/tests/test_process_observations.py
+++ b/app/tests/test_process_observations.py
@@ -276,7 +276,7 @@ async def test_process_event_doesnt_call_smart_with_invalid_uuid(
     mock_gundi_client,
     mock_pubsub_client,
     mock_smart_async_client_class,
-    raw_observation_geoevent,
+    raw_observation_geoevent_for_smart,
     raw_observation_geoevent_attributes,
     mock_send_observation_to_dead_letter_topic,
     smart_outbound_configuration_gcp_pubsub,
@@ -299,8 +299,10 @@ async def test_process_event_doesnt_call_smart_with_invalid_uuid(
         "app.services.process_messages.send_observation_to_dead_letter_topic",
         mock_send_observation_to_dead_letter_topic
     )
+    mocker.patch("app.services.process_messages.pubsub", mock_pubsub_client)
+
     await process_observation(
-        raw_observation_geoevent, raw_observation_geoevent_attributes
+        raw_observation_geoevent_for_smart, raw_observation_geoevent_attributes
     )
 
     # Check that we don't make extra requests to smart

--- a/app/tests/test_process_observations.py
+++ b/app/tests/test_process_observations.py
@@ -265,7 +265,7 @@ async def test_retry_process_event_on_smart_error_and_send_to_dlq(
     )
 
     # Check that is retried and then sent to the dead letter topic
-    assert mock_smart_async_client_class_with_server_error.retrurn_value.get_incident.call_count == 3
+    assert mock_smart_async_client_class_with_server_error.return_value.get_incident.call_count == 3
     assert mock_send_observation_to_dead_letter_topic.called
 
 

--- a/app/tests/test_process_observations.py
+++ b/app/tests/test_process_observations.py
@@ -229,3 +229,81 @@ async def test_process_observation_cameratrap_and_route_to_gcp_pubsub_dispatcher
     # Check that the right methods, to publish to PuSub, were called
     assert mock_pubsub_client.PublisherClient.called
     assert mock_pubsub_client.PublisherClient.return_value.publish.called
+
+
+@pytest.mark.asyncio
+async def test_retry_process_event_on_smart_error_and_send_to_dlq(
+    mocker,
+    mock_cache,
+    mock_gundi_client,
+    mock_smart_async_client_class_with_server_error,
+    mock_send_observation_to_dead_letter_topic,
+    raw_observation_geoevent_with_valid_uuid,
+    raw_observation_geoevent_attributes,
+    smart_outbound_configuration_gcp_pubsub,
+):
+    # Override gundi client mock to return a smart destination
+    mock_gundi_client.get_outbound_integration.return_value = async_return(
+        smart_outbound_configuration_gcp_pubsub
+    )
+    mock_gundi_client.get_outbound_integration_list.return_value = async_return(
+        [smart_outbound_configuration_gcp_pubsub]
+    )
+    # Mock external dependencies
+    mocker.patch("app.core.gundi._cache_db", mock_cache)
+    mocker.patch("app.core.gundi._portal", mock_gundi_client)
+    mocker.patch(
+        "app.services.transformers.AsyncSmartClient",
+        mock_smart_async_client_class_with_server_error,
+    )
+    mocker.patch(
+        "app.services.process_messages.send_observation_to_dead_letter_topic",
+        mock_send_observation_to_dead_letter_topic
+    )
+    await process_observation(
+        raw_observation_geoevent_with_valid_uuid, raw_observation_geoevent_attributes
+    )
+
+    # Check that is retried and then sent to the dead letter topic
+    assert mock_smart_async_client_class_with_server_error.retrurn_value.get_incident.call_count == 3
+    assert mock_send_observation_to_dead_letter_topic.called
+
+
+@pytest.mark.asyncio
+async def test_process_event_doesnt_call_smart_with_invalid_uuid(
+    mocker,
+    mock_cache,
+    mock_gundi_client,
+    mock_pubsub_client,
+    mock_smart_async_client_class,
+    raw_observation_geoevent,
+    raw_observation_geoevent_attributes,
+    mock_send_observation_to_dead_letter_topic,
+    smart_outbound_configuration_gcp_pubsub,
+):
+    # Override gundi client mock to return a smart destination
+    mock_gundi_client.get_outbound_integration.return_value = async_return(
+        smart_outbound_configuration_gcp_pubsub
+    )
+    mock_gundi_client.get_outbound_integration_list.return_value = async_return(
+        [smart_outbound_configuration_gcp_pubsub]
+    )
+    # Mock external dependencies
+    mocker.patch("app.core.gundi._cache_db", mock_cache)
+    mocker.patch("app.core.gundi._portal", mock_gundi_client)
+    mocker.patch(
+        "app.services.transformers.AsyncSmartClient",
+        mock_smart_async_client_class,
+    )
+    mocker.patch(
+        "app.services.process_messages.send_observation_to_dead_letter_topic",
+        mock_send_observation_to_dead_letter_topic
+    )
+    await process_observation(
+        raw_observation_geoevent, raw_observation_geoevent_attributes
+    )
+
+    # Check that we don't make extra requests to smart
+    assert not mock_smart_async_client_class.retrurn_value.get_incident.called
+    # Check that message was Not sent to teh dead letter
+    assert not mock_send_observation_to_dead_letter_topic.called

--- a/app/tests/test_process_observations.py
+++ b/app/tests/test_process_observations.py
@@ -307,3 +307,45 @@ async def test_process_event_doesnt_call_smart_with_invalid_uuid(
     assert not mock_smart_async_client_class.return_value.get_incident.called
     # Check that message was Not sent to teh dead letter
     assert not mock_send_observation_to_dead_letter_topic.called
+
+
+@pytest.mark.asyncio
+async def test_process_event_publishes_smart_event(
+    mocker,
+    mock_cache,
+    mock_gundi_client,
+    mock_pubsub_client,
+    mock_smart_async_client_class,
+    raw_observation_geoevent_for_smart,
+    raw_observation_geoevent_attributes,
+    mock_send_observation_to_dead_letter_topic,
+    smart_outbound_configuration_gcp_pubsub,
+):
+    # Override gundi client mock to return a smart destination
+    mock_gundi_client.get_outbound_integration.return_value = async_return(
+        smart_outbound_configuration_gcp_pubsub
+    )
+    mock_gundi_client.get_outbound_integration_list.return_value = async_return(
+        [smart_outbound_configuration_gcp_pubsub]
+    )
+    # Mock external dependencies
+    mocker.patch("app.core.gundi._cache_db", mock_cache)
+    mocker.patch("app.core.gundi._portal", mock_gundi_client)
+    mocker.patch(
+        "app.services.transformers.AsyncSmartClient",
+        mock_smart_async_client_class,
+    )
+    mocker.patch(
+        "app.services.process_messages.send_observation_to_dead_letter_topic",
+        mock_send_observation_to_dead_letter_topic
+    )
+
+    mocker.patch("app.services.process_messages.pubsub", mock_pubsub_client)
+
+    await process_observation(
+        raw_observation_geoevent_for_smart, raw_observation_geoevent_attributes
+    )
+
+    assert mock_pubsub_client.PublisherClient.called
+    assert mock_pubsub_client.PublisherClient.return_value.publish.called
+

--- a/requirements.in
+++ b/requirements.in
@@ -11,7 +11,7 @@ aioredis==2.0.1
 hiredis==2.3.2
 packaging==23.0
 https://github.com/PADAS/er-client/releases/download/v1.2.0-alpha/earthranger_client-1.2.0-py3-none-any.whl
-https://github.com/PADAS/smartconnect-client/releases/download/v1.5.3/smartconnect_client-1.5.3-py3-none-any.whl
+https://github.com/PADAS/smartconnect-client/releases/download/v1.7.0/smartconnect_client-1.7.0-py3-none-any.whl
 gundi-client==1.0.2
 gundi-client-v2==2.3.0
 gundi-core==1.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -279,7 +279,7 @@ six==1.16.0
     # via
     #   google-auth
     #   python-dateutil
-smartconnect-client @ https://github.com/PADAS/smartconnect-client/releases/download/v1.5.3/smartconnect_client-1.5.3-py3-none-any.whl
+smartconnect-client @ https://github.com/PADAS/smartconnect-client/releases/download/v1.7.0/smartconnect_client-1.7.0-py3-none-any.whl
     # via -r requirements.in
 sniffio==1.3.0
     # via

--- a/terraform/environments/prod/terragrunt.hcl
+++ b/terraform/environments/prod/terragrunt.hcl
@@ -16,6 +16,6 @@ inputs = {
   keycloak_issuer                   = "https://cdip-auth.pamdas.org/auth/realms/cdip-prod"
   redis_host                        = "10.208.106.172"
   movebank_dispatcher_default_topic = "destination-movebank-prod"
-  max_event_age_seconds             = "86400"
+  max_event_age_seconds             = "120"
   max_instance_count                = 20
 }


### PR DESCRIPTION
This is a hotfix to avoid send messages to the dead-letter on transformation errors, to avoid gcp retries and let other messages to get processed.