### PR TITLE
GUNDI-3398: Support WPS Watch in v2

### DIFF
--- a/app/conftest.py
+++ b/app/conftest.py
@@ -985,6 +985,92 @@ def destination_integration_v2():
 
 
 @pytest.fixture
+def destination_integration_v2_wpswatch():
+    return schemas_v2.Integration.parse_obj(
+        {
+            "id": "79bef222-74aa-4065-88a8-ac9656246693",
+            "name": "WPS Watch QA",
+            "base_url": "https://wpswatch-api-qa.azurewebsites.net",
+            "enabled": True,
+            "type": {
+                "id": "80bda69d-51ed-4c33-8420-0104e62d6639",
+                "name": "WPS Watch QA",
+                "value": "wps_watch",
+                "description": "",
+                "actions": [
+                    {
+                        "id": "1c9e2383-8154-404a-90b1-f4c591627d51",
+                        "type": "auth",
+                        "name": "Authenticate",
+                        "value": "auth",
+                        "description": "",
+                        "schema": {
+                            "type": "object",
+                            "required": ["api_key"],
+                            "properties": {"api_key": {"type": "string"}},
+                        },
+                    },
+                    {
+                        "id": "1109d75f-6456-4060-b2da-385e9ddde554",
+                        "type": "push",
+                        "name": "Push Events",
+                        "value": "push_events",
+                        "description": "",
+                        "schema": {
+                            "type": "object",
+                            "required": ["upload_domain"],
+                            "properties": {"upload_domain": {"type": "string"}},
+                        },
+                    },
+                ],
+                "webhook": None,
+            },
+            "owner": {
+                "id": "a91b400b-482a-4546-8fcb-ee42b01deeb6",
+                "name": "Test Org",
+                "description": "",
+            },
+            "configurations": [
+                {
+                    "id": "92d9fb49-f3c6-473f-9220-59745e854da5",
+                    "integration": "79bef222-74aa-4065-88a8-ac9656246693",
+                    "action": {
+                        "id": "1109d75f-6456-4060-b2da-385e9ddde554",
+                        "type": "push",
+                        "name": "Push Events",
+                        "value": "push_events",
+                    },
+                    "data": {"upload_domain": "upload-qa.wpswatch.org"},
+                },
+                {
+                    "id": "61a55770-0cf4-42b9-9054-ba0222ee5bc3",
+                    "integration": "79bef222-74aa-4065-88a8-ac9656246693",
+                    "action": {
+                        "id": "1c9e2383-8154-404a-90b1-f4c591627d51",
+                        "type": "auth",
+                        "name": "Authenticate",
+                        "value": "auth",
+                    },
+                    "data": {"api_key": "fakekey123"},  # pragma: allowlist secret
+                },
+            ],
+            "webhook_configuration": None,
+            "additional": {
+                "topic": "wpswatch-api-qa-wpswatch-sTHDqqN-topic",
+                "broker": "gcp_pubsub",
+            },
+            "default_route": None,
+            "status": {
+                "id": "mockid-b16a-4dbd-ad32-197c58aeef59",
+                "is_healthy": True,
+                "details": "Last observation has been delivered with success.",
+                "observation_delivered_24hrs": 50231,
+                "last_observation_delivered_at": "2023-03-31T11:20:00+0200",
+            },
+        }
+    )
+
+@pytest.fixture
 def connection_v2():
     return schemas_v2.Connection.parse_obj(
         {
@@ -1033,6 +1119,63 @@ def connection_v2():
             },
             "owner": {
                 "id": "e2d1b0fc-69fe-408b-afc5-7f54872730c0",
+                "name": "Test Organization",
+                "description": "",
+            },
+            "status": "healthy",
+        }
+    )
+
+
+@pytest.fixture
+def connection_v2_traptagger_to_wpswatch():
+    return schemas_v2.Connection.parse_obj(
+        {
+            "id": "ddd0946d-15b0-4308-b93d-e0470b6d33b6",
+            "provider": {
+                "id": "ddd0946d-15b0-4308-b93d-e0470b6d33b6",
+                "name": "Trap Tagger",
+                "owner": {
+                    "id": "a91b400b-482a-4546-8fcb-ee42b01deeb6",
+                    "name": "Test Organization",
+                },
+                "type": {
+                    "id": "190e3710-3a29-4710-b932-f951222209a7",
+                    "name": "TrapTagger",
+                    "value": "traptagger",
+                },
+                "base_url": "https://test.traptagger.com",
+                "status": "healthy",
+            },
+            "destinations": [
+                {
+                    "id": "79bef222-74aa-4065-88a8-ac9656246693",
+                    "name": "WPS Watch QA",
+                    "owner": {
+                        "id": "a91b400b-482a-4546-8fcb-ee42b01deeb6",
+                        "name": "Test Organization",
+                    },
+                    "type": {
+                        "id": "45c66a61-71e4-4664-a7f2-30d465f87aa6",
+                        "name": "WPS Watch",
+                        "value": "wps_watch",
+                    },
+                    "base_url": "https://wpswatch-api-qa.azurewebsites.net",
+                    "status": "healthy",
+                }
+            ],
+            "routing_rules": [
+                {
+                    "id": "835897f9-1ef2-4d99-9c6c-ea2663380c1f",
+                    "name": "TrapTagger Default Route",
+                }
+            ],
+            "default_route": {
+                "id": "835897f9-1ef2-4d99-9c6c-ea2663380c1f",
+                "name": "TrapTagger Default Route",
+            },
+            "owner": {
+                "id": "a91b400b-482a-4546-8fcb-ee42b01deeb6",
                 "name": "Test Organization",
                 "description": "",
             },
@@ -1476,6 +1619,20 @@ def animals_sign_event_v2():
         },
         geometry={},
         observation_type="ev",
+    )
+
+
+@pytest.fixture
+def photo_attachment_v2():
+    return schemas_v2.Attachment(
+        gundi_id="9bedc03e-8415-46db-aa70-782490cdff31",
+        related_to="b9b46dc1-e033-447d-a99b-0fe373ca04c9",
+        owner="a91b400b-482a-4546-8fcb-ee42b01deeb6",
+        data_provider_id="d88ac520-2bf6-4e6b-ab09-38ed1ec6947a",
+        source_id="ea2d5fca-752a-4a44-b170-668d780db85e",
+        external_source_id="gunditest",
+        file_path="attachments/9bedc03e-8415-46db-aa70-782490cdff31_elephant.jpg",
+        observation_type="att"
     )
 
 

--- a/app/services/event_handlers.py
+++ b/app/services/event_handlers.py
@@ -1,7 +1,15 @@
 import logging
 from gundi_core.events import ObservationReceived, EventReceived, EventUpdateReceived, AttachmentReceived
-from gundi_core.events.transformers import EventTransformedER, EventUpdateTransformedER, AttachmentTransformedER, \
-    ObservationTransformedER, EventTransformedSMART, EventUpdateTransformedSMART
+from gundi_core.events.transformers import (
+    EventTransformedER,
+    EventUpdateTransformedER,
+    AttachmentTransformedER,
+    ObservationTransformedER,
+    EventTransformedSMART,
+    EventUpdateTransformedSMART,
+    EventTransformedWPSWatch,
+    AttachmentTransformedWPSWatch
+)
 from opentelemetry.trace import SpanKind
 from app.core import tracing
 from app.core.errors import ReferenceDataError
@@ -28,7 +36,9 @@ transformer_events_by_data_type = {
     "ERAttachment": AttachmentTransformedER,
     "ERObservation": ObservationTransformedER,
     "SMARTCompositeRequest": EventTransformedSMART,
-    "SMARTUpdateRequest": EventUpdateTransformedSMART
+    "SMARTUpdateRequest": EventUpdateTransformedSMART,
+    "WPSWatchImageMetadata": EventTransformedWPSWatch,
+    "WPSWatchImage": AttachmentTransformedWPSWatch
 }
 
 

--- a/app/services/transformers.py
+++ b/app/services/transformers.py
@@ -1490,6 +1490,42 @@ class ERAttachmentTransformer(Transformer):
         )
 
 
+class WPSWatchEventTransformerV2(Transformer):
+
+    async def transform(
+        self, message: schemas.v2.Event, rules: list = None, **kwargs
+    ) -> schemas.v2.WPSWatchImageMetadata:
+        transformed_event_fields = dict(
+            camera_id=message.external_source_id
+        )
+        # Apply extra transformation rules as needed
+        if rules:
+            for rule in rules:
+                rule.apply(message=transformed_event_fields)
+        wps_image_metadata = schemas.v2.WPSWatchImageMetadata(
+            **transformed_event_fields
+        )
+        return wps_image_metadata
+
+
+class WPSWatchAttachmentTransformerV2(Transformer):
+
+    async def transform(
+        self, message: schemas.v2.Attachment, rules: list = None, **kwargs
+    ) -> schemas.v2.WPSWatchImage:
+        transformed_attachment_fields = dict(
+            file_path=message.file_path
+        )
+        # Apply extra transformation rules as needed
+        if rules:
+            for rule in rules:
+                rule.apply(message=transformed_attachment_fields)
+        wps_image = schemas.v2.WPSWatchImage(
+            **transformed_attachment_fields
+        )
+        return wps_image
+
+
 class ERObservationTransformer(Transformer):
     async def transform(
         self, message: schemas.v2.Observation, rules: list = None, **kwargs
@@ -1706,7 +1742,7 @@ async def transform_observation_to_destination_schema(
     provider=None,
     gundi_version="v1",
     route_configuration=None,
-) -> dict:
+):
     if gundi_version == "v2":
         return await transform_observation_v2(
             observation=observation,
@@ -1850,13 +1886,15 @@ transformers_map = {
     schemas.v2.StreamPrefixEnum.event.value: {
         schemas.DestinationTypes.EarthRanger.value: EREventTransformer,
         schemas.DestinationTypes.SmartConnect.value: SmartEventTransformerV2,
+        schemas.DestinationTypes.WPSWatch.value: WPSWatchEventTransformerV2
     },
     schemas.v2.StreamPrefixEnum.event_update.value: {
         schemas.DestinationTypes.EarthRanger.value: EREventUpdateTransformer,
         schemas.DestinationTypes.SmartConnect.value: SmartEventUpdateTransformerV2,
     },
     schemas.v2.StreamPrefixEnum.attachment.value: {
-        schemas.DestinationTypes.EarthRanger.value: ERAttachmentTransformer
+        schemas.DestinationTypes.EarthRanger.value: ERAttachmentTransformer,
+        schemas.DestinationTypes.WPSWatch.value: WPSWatchAttachmentTransformerV2
     },
     schemas.v2.StreamPrefixEnum.observation.value: {
         schemas.DestinationTypes.Movebank.value: MBObservationTransformer,

--- a/requirements.in
+++ b/requirements.in
@@ -12,9 +12,9 @@ hiredis==2.3.2
 packaging==23.0
 https://github.com/PADAS/er-client/releases/download/v1.2.0-alpha/earthranger_client-1.2.0-py3-none-any.whl
 https://github.com/PADAS/smartconnect-client/releases/download/v1.5.3/smartconnect_client-1.5.3-py3-none-any.whl
-gundi-client==1.0.2
-gundi-client-v2==2.3.3
-gundi-core==1.5.9
+gundi-client==1.0.4
+gundi-client-v2==2.3.5
+gundi-core==1.6.1
 opentelemetry-api==1.14.0
 opentelemetry-sdk==1.14.0
 opentelemetry-exporter-gcp-trace==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -103,11 +103,11 @@ grpcio==1.56.2
     #   grpcio-status
 grpcio-status==1.48.2
     # via google-api-core
-gundi-client==1.0.2
+gundi-client==1.0.4
     # via -r requirements.in
-gundi-client-v2==2.3.3
+gundi-client-v2==2.3.5
     # via -r requirements.in
-gundi-core==1.5.9
+gundi-core==1.6.1
     # via
     #   -r requirements.in
     #   gundi-client

--- a/test_local.sh
+++ b/test_local.sh
@@ -8,16 +8,16 @@ curl localhost:8282 \
   -H "ce-source: //pubsub.googleapis.com/projects/MY-PROJECT/topics/MY-TOPIC" \
   -d '{
       "message": {
-        "data":"eyJldmVudF9pZCI6ICJjMTQxMmZiZi0xNTcwLTQ0YjAtOGE3ZC00MTFlZGUzMDFmMzciLCAidGltZXN0YW1wIjogIjIwMjQtMDgtMDIgMTE6MTg6MDQuNzIyNTI4KzAwOjAwIiwgInNjaGVtYV92ZXJzaW9uIjogInYxIiwgInBheWxvYWQiOiB7Imd1bmRpX2lkIjogIjU0NmI5MjdiLTU3OGMtNDUwNC05OWNlLWE0Mjg5NTI4NDk0MSIsICJyZWxhdGVkX3RvIjogIk5vbmUiLCAib3duZXIiOiAiYTkxYjQwMGItNDgyYS00NTQ2LThmY2ItZWU0MmIwMWRlZWI2IiwgImRhdGFfcHJvdmlkZXJfaWQiOiAiZDg4YWM1MjAtMmJmNi00ZTZiLWFiMDktMzhlZDFlYzY5NDdhIiwgInNvdXJjZV9pZCI6ICIyOTY2OWIxNy1jODg4LTRjNmQtODdiNS1kOGI5ZTE0ZTM0MmQiLCAiZXh0ZXJuYWxfc291cmNlX2lkIjogImRlZmF1bHQtc291cmNlIiwgImNoYW5nZXMiOiB7InRpdGxlIjogIkFuaW1hbHMgMDIgRWRpdGVkIChUZXN0IE1hcmlhbm8pIiwgInJlY29yZGVkX2F0IjogIjIwMjQtMDgtMDIgMTA6NDY6MTArMDA6MDAiLCAibG9jYXRpb24iOiB7ImxhdCI6IDEzLjEyMzQ1NiwgImxvbiI6IDEzLjEyMzQ1Nn0sICJldmVudF90eXBlIjogImFuaW1hbHMiLCAiZXZlbnRfZGV0YWlscyI6IHsidGFyZ2V0c3BlY2llcyI6ICJyZXB0aWxlcy5weXRob25zcHAiLCAid2lsZGxpZmVvYnNlcnZhdGlvbnR5cGUiOiAiZGlyZWN0b2JzZXJ2YXRpb24iLCAiYWdlb2ZzaWduYW5pbWFsIjogImZyZXNoIiwgIm51bWJlcm9mYW5pbWFsIjogMn19LCAib2JzZXJ2YXRpb25fdHlwZSI6ICJldnUifSwgImV2ZW50X3R5cGUiOiAiRXZlbnRVcGRhdGVSZWNlaXZlZCJ9",
+        "data":"eyJldmVudF9pZCI6ICI5MzE5NDA0Yy1hMDJhLTQwMzgtYWQ4OC1kNzUwMmU3OGMyMDMiLCAidGltZXN0YW1wIjogIjIwMjQtMDctMjQgMjA6MTM6MzMuNjk1MDE0KzAwOjAwIiwgInNjaGVtYV92ZXJzaW9uIjogInYxIiwgInBheWxvYWQiOiB7Imd1bmRpX2lkIjogIjliZWRjMDNlLTg0MTUtNDZkYi1hYTcwLTc4MjQ5MGNkZmYzMSIsICJyZWxhdGVkX3RvIjogIjZjYjgyMTgyLTUxYjItNDMwOS1iYTgzLWM5OWVkOGU2MWFlOCIsICJvd25lciI6ICJuYSIsICJkYXRhX3Byb3ZpZGVyX2lkIjogImQ4OGFjNTIwLTJiZjYtNGU2Yi1hYjA5LTM4ZWQxZWM2OTQ3YSIsICJzb3VyY2VfaWQiOiAiZWEyZDVmY2EtNzUyYS00YTQ0LWIxNzAtNjY4ZDc4MGRiODVlIiwgImV4dGVybmFsX3NvdXJjZV9pZCI6ICJndW5kaXRlc3QiLCAiZmlsZV9wYXRoIjogImF0dGFjaG1lbnRzLzliZWRjMDNlLTg0MTUtNDZkYi1hYTcwLTc4MjQ5MGNkZmYzMV93aWxkX2RvZy1tYWxlLnN2ZyIsICJvYnNlcnZhdGlvbl90eXBlIjogImF0dCJ9LCAiZXZlbnRfdHlwZSI6ICJBdHRhY2htZW50UmVjZWl2ZWQifQ==",
         "attributes":{
           "gundi_version":"v2",
-          "provider_key":"gundi_traptagger_ddd0946d-15b0-4308-b93d-e0470b6d33b6",
-          "gundi_id":"546b927b-578c-4504-99ce-a42895284941",
-          "related_to": "None",
-          "stream_type":"evu",
+          "provider_key":"gundi_traptagger_d88ac520-2bf6-4e6b-ab09-38ed1ec6947a",
+          "gundi_id":"9bedc03e-8415-46db-aa70-782490cdff31",
+          "related_to": "6cb82182-51b2-4309-ba83-c99ed8e61ae8",
+          "stream_type":"att",
           "source_id":"ea2d5fca-752a-4a44-b170-668d780db85e",
-          "external_source_id":"Xyz123",
-          "destination_id":"b42c9205-5228-49e0-a75b-ebe5b6a9f78e",
+          "external_source_id":"gunditest",
+          "destination_id":"79bef222-74aa-4065-88a8-ac9656246693",
           "data_provider_id":"d88ac520-2bf6-4e6b-ab09-38ed1ec6947a",
           "annotations":"{}",
           "tracing_context":"{}"
@@ -25,13 +25,14 @@ curl localhost:8282 \
       },
       "subscription": "projects/MY-PROJECT/subscriptions/MY-SUB"
     }'
+
 # AttachmentReceived
 #  -d '{
 #      "message": {
 #        "data":"eyJldmVudF9pZCI6ICI5MzE5NDA0Yy1hMDJhLTQwMzgtYWQ4OC1kNzUwMmU3OGMyMDMiLCAidGltZXN0YW1wIjogIjIwMjQtMDctMjQgMjA6MTM6MzMuNjk1MDE0KzAwOjAwIiwgInNjaGVtYV92ZXJzaW9uIjogInYxIiwgInBheWxvYWQiOiB7Imd1bmRpX2lkIjogIjliZWRjMDNlLTg0MTUtNDZkYi1hYTcwLTc4MjQ5MGNkZmYzMSIsICJyZWxhdGVkX3RvIjogIjZjYjgyMTgyLTUxYjItNDMwOS1iYTgzLWM5OWVkOGU2MWFlOCIsICJvd25lciI6ICJuYSIsICJkYXRhX3Byb3ZpZGVyX2lkIjogImY4NzBlMjI4LTRhNjUtNDBmMC04ODhjLTQxYmRjMTEyNGMzYyIsICJzb3VyY2VfaWQiOiAiTm9uZSIsICJleHRlcm5hbF9zb3VyY2VfaWQiOiAiTm9uZSIsICJmaWxlX3BhdGgiOiAiYXR0YWNobWVudHMvOWJlZGMwM2UtODQxNS00NmRiLWFhNzAtNzgyNDkwY2RmZjMxX3dpbGRfZG9nLW1hbGUuc3ZnIiwgIm9ic2VydmF0aW9uX3R5cGUiOiAiYXR0In0sICJldmVudF90eXBlIjogIkF0dGFjaG1lbnRSZWNlaXZlZCJ9",
 #        "attributes":{
 #          "gundi_version":"v2",
-#          "provider_key":"gundi_traptagger_ddd0946d-15b0-4308-b93d-e0470b6d33b6",
+#          "provider_key":"gundi_traptagger_d88ac520-2bf6-4e6b-ab09-38ed1ec6947a",
 #          "gundi_id":"9bedc03e-8415-46db-aa70-782490cdff31",
 #          "related_to": "6cb82182-51b2-4309-ba83-c99ed8e61ae8",
 #          "stream_type":"att",
@@ -59,6 +60,26 @@ curl localhost:8282 \
 #          "external_source_id":"Xyz123",
 #          "destination_id":"f45b1d48-46fc-414b-b1ca-7b56b87b2020",
 #          "data_provider_id":"d88ac520-2bf6-4e6b-ab09-38ed1ec6947a",
+#          "annotations":"{}",
+#          "tracing_context":"{}"
+#        }
+#      },
+#      "subscription": "projects/MY-PROJECT/subscriptions/MY-SUB"
+#    }'
+# EventUpdateReceived for WPS Watch
+#  -d '{
+#      "message": {
+#        "data":"eyJldmVudF9pZCI6ICIyZGZkZDc3ZS0zY2RlLTQyNjktYjJhOC1kZTAxMzc0ZDMyOTQiLCAidGltZXN0YW1wIjogIjIwMjQtMDctMjQgMTQ6MTg6NDEuOTUxMjQxKzAwOjAwIiwgInNjaGVtYV92ZXJzaW9uIjogInYxIiwgInBheWxvYWQiOiB7Imd1bmRpX2lkIjogIjJhMWUwZTZjLTMzNGYtNDJmZS05ZDQ1LTEyYzM0ZWQ0ODY2ZiIsICJvd25lciI6ICJhOTFiNDAwYi00ODJhLTQ1NDYtOGZjYi1lZTQyYjAxZGVlYjYiLCAiZGF0YV9wcm92aWRlcl9pZCI6ICJkODhhYzUyMC0yYmY2LTRlNmItYWIwOS0zOGVkMWVjNjk0N2EiLCAiYW5ub3RhdGlvbnMiOiB7fSwgInNvdXJjZV9pZCI6ICJhYzFiOWNkYy1hMTkzLTQ1MTUtYjQ0Ni1iMTc3YmNjNWYzNDIiLCAiZXh0ZXJuYWxfc291cmNlX2lkIjogImNhbWVyYTEyMyIsICJyZWNvcmRlZF9hdCI6ICIyMDI0LTA3LTI0IDE0OjE4OjEyKzAwOjAwIiwgImxvY2F0aW9uIjogeyJsYXQiOiAxMy42ODg2MzUsICJsb24iOiAxMy43ODMwNjUsICJhbHQiOiAwLjB9LCAidGl0bGUiOiAiQW5pbWFsIERldGVjdGVkIFRlc3QgRXZlbnQiLCAiZXZlbnRfdHlwZSI6ICJ3aWxkbGlmZV9zaWdodGluZ19yZXAiLCAiZXZlbnRfZGV0YWlscyI6IHsic3BlY2llcyI6ICJMaW9uIn0sICJvYnNlcnZhdGlvbl90eXBlIjogImV2In0sICJldmVudF90eXBlIjogIkV2ZW50UmVjZWl2ZWQifQ==",
+#        "attributes":{
+#          "gundi_version":"v2",
+#          "provider_key":"gundi_traptagger_ddd0946d-15b0-4308-b93d-e0470b6d33b6",
+#          "gundi_id":"6cb82182-51b2-4309-ba83-c99ed8e61ae8",
+#          "related_to": "None",
+#          "stream_type":"ev",
+#          "source_id":"ea2d5fca-752a-4a44-b170-668d780db85e",
+#          "external_source_id":"Xyz123",
+#          "destination_id":"79bef222-74aa-4065-88a8-ac9656246693",
+#          "data_provider_id":"ddd0946d-15b0-4308-b93d-e0470b6d33b6",
 #          "annotations":"{}",
 #          "tracing_context":"{}"
 #        }


### PR DESCRIPTION
### What does this PR do?
- Adds support for processing events and attachments for WPS Watch in Gundi v2.
- Adds basic test coverage
- Updates sample data in the local testing script with events and attachments for WPS Watch


### Relevant link(s)
[GUNDI-3398](https://allenai.atlassian.net/browse/GUNDI-3398)

[GUNDI-3398]: https://allenai.atlassian.net/browse/GUNDI-3398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ