### PR TITLE
GUNDI-3401: Support status field in ER transformers

### DIFF
--- a/app/conftest.py
+++ b/app/conftest.py
@@ -1525,6 +1525,23 @@ def event_update_location_full():
     )
 
 
+@pytest.fixture
+def event_update_status_resolved():
+    return schemas_v2.EventUpdate(
+        gundi_id="78867a74-67f0-4b56-8e44-125ae66408ff",
+        related_to=None,
+        owner="a91b400b-482a-4546-8fcb-ee42b01deeb6",
+        data_provider_id="ddd0946d-15b0-4308-b93d-e0470b6d33b6",
+        annotations=None,
+        source_id="ac1b9cdc-a193-4515-b446-b177bcc5f342",
+        external_source_id="camera123",
+        changes={
+            "status": "resolved"
+        },
+        observation_type="evu"
+    )
+
+
 from smartconnect.models import (
     SMARTRequest,
     SmartAttributes,
@@ -1623,6 +1640,33 @@ def animals_sign_event_v2():
 
 
 @pytest.fixture
+def animals_sign_event_with_status():
+    return schemas_v2.Event(
+        gundi_id="c1b46dc1-b144-556c-c87a-2ef373ca04b0",
+        owner="e2d1b0fc-69fe-408b-afc5-7f54872730c0",
+        data_provider_id="ddd0946d-15b0-4308-b93d-e0470b6d33b6",
+        annotations={},
+        source_id="afa0d606-c143-4705-955d-68133645db6d",
+        external_source_id="Xyz123",
+        recorded_at=datetime.datetime(
+            2023, 12, 28, 19, 26, tzinfo=datetime.timezone.utc
+        ),
+        location=schemas_v2.Location(
+            lat=-51.688645, lon=-72.704440, alt=1800.0, hdop=None, vdop=None
+        ),
+        title="Animal Sign",
+        event_type="animals_sign",
+        event_details={
+            "species": "lion",
+            "ageofsign": "days",
+        },
+        geometry={},
+        status="active",
+        observation_type="ev",
+    )
+
+
+@pytest.fixture
 def photo_attachment_v2():
     return schemas_v2.Attachment(
         gundi_id="9bedc03e-8415-46db-aa70-782490cdff31",
@@ -1684,6 +1728,7 @@ def animals_sign_event_update_v2():
                 "species": "puma",
                 "ageofsign": "weeks",
             },
+            "status": "resolved"
         },
         observation_type="evu",
     )

--- a/app/services/transformers.py
+++ b/app/services/transformers.py
@@ -1452,6 +1452,7 @@ class EREventUpdateTransformer(Transformer):
             "event_details": "event_details",
             "recorded_at": "time",
             "location": "location",
+            "status": "state",
         }
 
     async def transform(

--- a/app/services/transformers.py
+++ b/app/services/transformers.py
@@ -1429,7 +1429,8 @@ class EREventTransformer(Transformer):
             location=dict(
                 longitude=message.location.lon, latitude=message.location.lat
             ),
-            geometry=message.geometry
+            geometry=message.geometry,
+            state=message.status
         )
         # Apply extra transformation rules as needed
         if rules:

--- a/app/tests/test_transform_observations_v2.py
+++ b/app/tests/test_transform_observations_v2.py
@@ -162,6 +162,26 @@ async def test_transform_events_without_route_configuration(
 
 
 @pytest.mark.asyncio
+async def test_transform_events_with_status_for_earthranger(
+    mock_cache,
+    mock_gundi_client_v2,
+    mock_pubsub_client,
+    animals_sign_event_with_status,
+    destination_integration_v2_er,
+    connection_v2,
+):
+    transformed_observation = await transform_observation_v2(
+        observation=animals_sign_event_with_status,
+        destination=destination_integration_v2_er,
+        provider=connection_v2.provider,
+        route_configuration=None,
+    )
+    assert transformed_observation
+    assert transformed_observation.state
+    assert transformed_observation.state == animals_sign_event_with_status.status
+
+
+@pytest.mark.asyncio
 async def test_provider_key_mapping_with_default(
     mock_cache,
     mock_gundi_client_v2,
@@ -525,6 +545,25 @@ async def test_transform_event_update_full_location_with_type_mapping_for_earthr
     }
     assert transformed_observation.changes.get("location") == er_location_changes
     assert "event_type" not in transformed_observation.changes
+
+
+@pytest.mark.asyncio
+async def test_transform_event_update_status_resolved_for_earthranger(
+    mock_cache,
+    mock_gundi_client_v2,
+    mock_pubsub_client,
+    event_update_status_resolved,
+    destination_integration_v2_er,
+    connection_v2,
+):
+    transformed_observation = await transform_observation_v2(
+        observation=event_update_status_resolved,
+        destination=destination_integration_v2_er,
+        provider=connection_v2.provider,
+        route_configuration=None,
+    )
+    assert transformed_observation.changes
+    assert transformed_observation.changes.get("state") == "resolved"
 
 
 @pytest.mark.asyncio

--- a/requirements.in
+++ b/requirements.in
@@ -14,7 +14,7 @@ https://github.com/PADAS/er-client/releases/download/v1.2.0-alpha/earthranger_cl
 https://github.com/PADAS/smartconnect-client/releases/download/v1.5.3/smartconnect_client-1.5.3-py3-none-any.whl
 gundi-client==1.0.4
 gundi-client-v2==2.3.5
-gundi-core==1.6.1
+gundi-core==1.6.2
 opentelemetry-api==1.14.0
 opentelemetry-sdk==1.14.0
 opentelemetry-exporter-gcp-trace==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -107,7 +107,7 @@ gundi-client==1.0.4
     # via -r requirements.in
 gundi-client-v2==2.3.5
     # via -r requirements.in
-gundi-core==1.6.1
+gundi-core==1.6.2
     # via
     #   -r requirements.in
     #   gundi-client


### PR DESCRIPTION
### What does this PR do?
- Maps the `status` field to `state` in ER transformers, for new events and updates.
- Updates `gundi-core` version to get the latest Event model supporting status
- Test coverage

### Relevant link(s)
[GUNDI-3400](https://allenai.atlassian.net/browse/GUNDI-3400)

[GUNDI-3400]: https://allenai.atlassian.net/browse/GUNDI-3400?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ