### PR TITLE
GUNDI-4244: Fix provider key field mappings

### DIFF
--- a/app/conftest.py
+++ b/app/conftest.py
@@ -1681,6 +1681,72 @@ def route_v2():
 
 
 @pytest.fixture
+def route_v2_with_provider_key_field_mapping(connection_v2):
+    provider_id = str(connection_v2.provider.id)
+    destination_id = str(connection_v2.destinations[0].id)
+    return schemas_v2.Route.parse_obj(
+        {
+            "id": "835897f9-1ef2-4d99-9c6c-ea2663380c1f",
+            "name": "Telonics Migrated Connection Default Route",
+            "owner": "e2d1b0fc-69fe-408b-afc5-7f54872730c0",
+            "data_providers": [
+                {
+                    "id": provider_id,
+                    "name": "Telonics Migrated Connection",
+                    "owner": {
+                        "id": "e2d1b0fc-69fe-408b-afc5-7f54872730c0",
+                        "name": "Test Organization",
+                    },
+                    "type": {
+                        "id": "190e3710-3a29-4710-b932-f951222209a7",
+                        "name": "Telonics",
+                        "value": "telonics",
+                    },
+                    "base_url": "",
+                    "status": "healthy",
+                    "status_details": "",
+                }
+            ],
+            "destinations": [
+                {
+                    "id": destination_id,
+                    "name": "ER Load Testing",
+                    "owner": {
+                        "id": "e2d1b0fc-69fe-408b-afc5-7f54872730c0",
+                        "name": "Test Organization",
+                    },
+                    "type": {
+                        "id": "45c66a61-71e4-4664-a7f2-30d465f87aa6",
+                        "name": "EarthRanger",
+                        "value": "earth_ranger",
+                    },
+                    "base_url": "https://gundi-load-testing.pamdas.org",
+                    "status": "healthy",
+                    "status_details": "",
+                }
+            ],
+            "configuration": {
+                "id": "1a3e3e73-94ad-42cb-a765-09a7193ae0b1",
+                "name": "Telonics Migrated Connection - Provider key Mapping",
+                "data": {
+                    "field_mappings": {
+                        provider_id: {
+                            "obv": {
+                                destination_id: {
+                                    "default": "telonics-collars",
+                                    "destination_field": "provider_key",
+                                }
+                            }
+                        }
+                    }
+                },
+            },
+            "additional": {},
+        }
+    )
+
+
+@pytest.fixture
 def raw_observation_v2():
     return {
         "event_id": "d8523635-546e-4cd4-ad6a-d9fdf494698e",

--- a/app/services/event_handlers.py
+++ b/app/services/event_handlers.py
@@ -146,7 +146,9 @@ async def transform_and_route_observation(observation):
                     observation=observation,
                     destination=destination,
                     gundi_version="v2",
-                    provider_key=provider_key,
+                    provider_key=getattr(
+                        transformed_observation, "provider_key", provider_key
+                    ),  # Field mappings overrides take precedence
                 )
                 logger.debug(
                     f"Transformed observation: {repr(transformed_observation)}, attributes: {attributes}"

--- a/app/tests/test_process_observations_v2.py
+++ b/app/tests/test_process_observations_v2.py
@@ -1,4 +1,6 @@
 import pytest
+
+from app.conftest import async_return
 from app.services.process_messages import process_observation_event
 from app.core.utils import get_provider_key
 
@@ -20,6 +22,47 @@ async def test_process_observations_v2(
     # Check that the right methods, to publish to PuSub, were called
     assert mock_pubsub.PublisherClient.called
     assert mock_pubsub.PublisherClient.return_value.publish.called
+
+
+@pytest.mark.asyncio
+async def test_process_observations_v2_with_provider_key_field_mapping(
+    mocker,
+    mock_cache,
+    mock_gundi_client_v2,
+    connection_v2,
+    route_v2_with_provider_key_field_mapping,
+    mock_pubsub,
+    raw_observation_v2,
+    raw_observation_v2_attributes,
+):
+    # Set a field mapping for the provider key
+    mock_gundi_client_v2.get_route_details.return_value = async_return(
+        route_v2_with_provider_key_field_mapping
+    )
+    provider_id = str(connection_v2.provider.id)
+    destination_id = str(connection_v2.destinations[0].id)
+    raw_observation_v2["payload"]["data_provider_id"] = provider_id
+    mocker.patch("app.core.gundi._cache_db", mock_cache)
+    mocker.patch("app.core.gundi.portal_v2", mock_gundi_client_v2)
+    mocker.patch("app.core.pubsub.pubsub", mock_pubsub)
+    mock_send_message_to_gcp_pubsub_dispatcher = mocker.AsyncMock()
+    mocker.patch(
+        "app.services.event_handlers.send_message_to_gcp_pubsub_dispatcher",
+        mock_send_message_to_gcp_pubsub_dispatcher,
+    )
+
+    await process_observation_event(raw_observation_v2, raw_observation_v2_attributes)
+
+    # Check that the message for the dispatcher was sent with the correct provider key
+    assert mock_send_message_to_gcp_pubsub_dispatcher.call_count == 1
+    route_config_data = route_v2_with_provider_key_field_mapping.configuration.data
+    expected_provider_key = route_config_data["field_mappings"][provider_id]["obv"][
+        destination_id
+    ]["default"]
+    final_provider_key = mock_send_message_to_gcp_pubsub_dispatcher.call_args[1][
+        "attributes"
+    ]["provider_key"]
+    assert final_provider_key == expected_provider_key
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This PR fixes an issue that affected the `provider_key` overriding ability using field mappings.