### PR TITLE
GUNDI-4288: Add missing event mappings for messages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - main
       - 'release-**'
-      - gundi-4288-fix-messages
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -63,7 +62,7 @@ jobs:
 
   stage-deploy:
     uses: PADAS/gundi-workflows/.github/workflows/terragrunt.yml@v2
-    if: startsWith(github.ref, 'refs/heads/gundi-4288-fix-messages')
+    if: startsWith(github.ref, 'refs/heads/release')
     needs: [vars, run_unit_tests, build]
     with:
       environment: stage

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
       - 'release-**'
+      - gundi-4288-fix-messages
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -62,7 +63,7 @@ jobs:
 
   stage-deploy:
     uses: PADAS/gundi-workflows/.github/workflows/terragrunt.yml@v2
-    if: startsWith(github.ref, 'refs/heads/release')
+    if: startsWith(github.ref, 'refs/heads/gundi-4288-fix-messages')
     needs: [vars, run_unit_tests, build]
     with:
       environment: stage

--- a/app/services/event_handlers.py
+++ b/app/services/event_handlers.py
@@ -18,6 +18,8 @@ from gundi_core.events.transformers import (
     AttachmentTransformedWPSWatch,
     EventTransformedTrapTagger,
     AttachmentTransformedTrapTagger,
+    MessageTransformedER,
+    MessageTransformedInReach,
 )
 from opentelemetry.trace import SpanKind
 from app.core import tracing
@@ -50,6 +52,8 @@ transformer_events_by_data_type = {
     "WPSWatchImage": AttachmentTransformedWPSWatch,
     "TrapTaggerImageMetadata": EventTransformedTrapTagger,
     "TrapTaggerImage": AttachmentTransformedTrapTagger,
+    "ERMessage": MessageTransformedER,
+    "InReachIPCMessage": MessageTransformedInReach,
 }
 
 


### PR DESCRIPTION
This pull request updates the `event_handlers.py` file to add support for two new message types, `ERMessage` and `InReachIPCMessage`, by introducing corresponding transformation classes and mapping them appropriately.

### Additions to supported message types:

* Added new transformation classes `MessageTransformedER` and `MessageTransformedInReach` to the list of imports. (`[app/services/event_handlers.pyR21-R22](diffhunk://#diff-c60fa976d218dd97d3d3d1fc479052371f45395654a2232e09ed7c593f8c9f1aR21-R22)`)
* Mapped the new message types `"ERMessage"` and `"InReachIPCMessage"` to their respective transformation classes in the `message_type_to_transformer` dictionary. (`[app/services/event_handlers.pyR55-R56](diffhunk://#diff-c60fa976d218dd97d3d3d1fc479052371f45395654a2232e09ed7c593f8c9f1aR55-R56)`)