### PR TITLE
Fix ERMessage location schema

### DIFF
--- a/app/services/transformers.py
+++ b/app/services/transformers.py
@@ -1577,8 +1577,8 @@ class ERMessageTransformer(Transformer):
         }
         if message.location:
             transformed_message_fields["device_location"] = {
-                "lon": message.location.lon,
-                "lat": message.location.lat,
+                "longitude": message.location.lon,
+                "latitude": message.location.lat,
                 # Altitude or others are not supported by ER in the /messages/ endpoint
             }
 

--- a/app/tests/test_transform_observations_v2.py
+++ b/app/tests/test_transform_observations_v2.py
@@ -750,11 +750,11 @@ async def test_transform_text_message_for_earthranger(
     assert transformed_observation.message_time == text_message_from_inreach.created_at
     assert transformed_observation.device_location
     assert (
-        transformed_observation.device_location.lon
+        transformed_observation.device_location.longitude
         == text_message_from_inreach.location.lon
     )
     assert (
-        transformed_observation.device_location.lat
+        transformed_observation.device_location.latitude
         == text_message_from_inreach.location.lat
     )
     assert transformed_observation.additional == text_message_from_inreach.additional

--- a/requirements.in
+++ b/requirements.in
@@ -14,7 +14,7 @@ https://github.com/PADAS/er-client/releases/download/v1.3.0/earthranger_client-1
 https://github.com/PADAS/smartconnect-client/releases/download/v1.7.0/smartconnect_client-1.7.0-py3-none-any.whl
 gundi-client==1.0.4
 gundi-client-v2==2.3.8
-gundi-core==1.11.1
+gundi-core==1.11.2
 opentelemetry-api==1.14.0
 opentelemetry-sdk==1.14.0
 opentelemetry-exporter-gcp-trace==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -107,7 +107,7 @@ gundi-client==1.0.4
     # via -r requirements.in
 gundi-client-v2==2.3.8
     # via -r requirements.in
-gundi-core==1.11.1
+gundi-core==1.11.2
     # via
     #   -r requirements.in
     #   gundi-client


### PR DESCRIPTION
This pull request introduces updates to fix naming issues in message location fields, ensures corresponding test cases reflect these changes, and updates a dependency to its latest version.

### Naming consistency updates:
* [`app/services/transformers.py`](diffhunk://#diff-540d718ca7da47eaf4aedf931fa876ba492a764e9a9bb48f5e56f54fee3bfbb0L1580-R1581): Renamed `lon` to `longitude` and `lat` to `latitude` in the `device_location` field for better clarity and alignment with naming conventions.

### Test updates:
* [`app/tests/test_transform_observations_v2.py`](diffhunk://#diff-e42cafe44ebd7ea97000c5d43d130c189159355e5c64995e31e3baefd4b0fa0dL753-R757): Updated test assertions to match the new field names (`longitude` and `latitude`) in `device_location`.

### Dependency updates:
* [`requirements.in`](diffhunk://#diff-de469cc9cf8992ffaec661b4e087cfded3ec6da722072ec1fdf11f61690fd1b8L17-R17): Upgraded `gundi-core` from version `1.11.1` to `1.11.2` to incorporate the latest fixes or features.