### PR TITLE
GUNDI-3937: Optional lat lon in Events

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
       - 'release-**'
+      - 'gundi-3937-optional-lat-lon'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -62,7 +63,7 @@ jobs:
 
   stage-deploy:
     uses: PADAS/gundi-workflows/.github/workflows/terragrunt.yml@v2
-    if: startsWith(github.ref, 'refs/heads/release')
+    if: startsWith(github.ref, 'refs/heads/gundi-3937-optional-lat-lon')
     needs: [vars, run_unit_tests, build]
     with:
       environment: stage

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - main
       - 'release-**'
-      - 'gundi-3937-optional-lat-lon'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -63,7 +62,7 @@ jobs:
 
   stage-deploy:
     uses: PADAS/gundi-workflows/.github/workflows/terragrunt.yml@v2
-    if: startsWith(github.ref, 'refs/heads/gundi-3937-optional-lat-lon')
+    if: startsWith(github.ref, 'refs/heads/release')
     needs: [vars, run_unit_tests, build]
     with:
       environment: stage

--- a/app/conftest.py
+++ b/app/conftest.py
@@ -2324,6 +2324,30 @@ def animals_sign_event_v2():
 
 
 @pytest.fixture
+def animals_sign_event_v2_with_null_location():
+    return schemas_v2.Event(
+        gundi_id="c1b46dc1-b144-556c-c87a-2ef373ca04b0",
+        owner="e2d1b0fc-69fe-408b-afc5-7f54872730c0",
+        data_provider_id="ddd0946d-15b0-4308-b93d-e0470b6d33b6",
+        annotations={},
+        source_id="afa0d606-c143-4705-955d-68133645db6d",
+        external_source_id="Xyz123",
+        recorded_at=datetime.datetime(
+            2023, 12, 28, 19, 26, tzinfo=datetime.timezone.utc
+        ),
+        location=None,
+        title="Animal Sign",
+        event_type="animals_sign",
+        event_details={
+            "species": "lion",
+            "ageofsign": "days",
+        },
+        geometry={},
+        observation_type="ev",
+    )
+
+
+@pytest.fixture
 def animals_sign_event_with_status():
     return schemas_v2.Event(
         gundi_id="c1b46dc1-b144-556c-c87a-2ef373ca04b0",

--- a/app/services/transformers.py
+++ b/app/services/transformers.py
@@ -1503,12 +1503,17 @@ class EREventTransformer(Transformer):
             event_type=message.event_type,
             event_details=message.event_details,
             time=message.recorded_at,
-            location=dict(
-                longitude=message.location.lon, latitude=message.location.lat
-            ),
             geometry=message.geometry,
             state=message.status,
         )
+        if message.location:
+            transformed_event_fields["location"] = {
+                "longitude": message.location.lon,
+                "latitude": message.location.lat,
+                "altitude": message.location.alt,
+            }
+        else:
+            transformed_event_fields["location"] = None
         # Apply extra transformation rules as needed
         if rules:
             for rule in rules:
@@ -1660,8 +1665,8 @@ class TrapTaggerEventTransformer(Transformer):
         timestamp = recorded_at.strftime("%Y-%m-%d %H:%M:%S")
         transformed_event_fields = {
             "camera": message.external_source_id,
-            "latitude": message.location.lat,
-            "longitude": message.location.lon,
+            "latitude": message.location.lat if message.location else 0.0,
+            "longitude": message.location.lon if message.location else 0.0,
             "timestamp": timestamp,
         }
         # Apply extra transformation rules as needed

--- a/app/tests/test_transform_observations_v2.py
+++ b/app/tests/test_transform_observations_v2.py
@@ -189,6 +189,26 @@ async def test_transform_events_with_status_for_earthranger(
 
 
 @pytest.mark.asyncio
+async def test_transform_event_with_null_location_for_earthranger(
+    mock_cache,
+    mock_gundi_client_v2,
+    mock_pubsub,
+    animals_sign_event_v2_with_null_location,
+    destination_integration_v2_er,
+    connection_v2,
+):
+    transformed_observation = await transform_observation_v2(
+        observation=animals_sign_event_v2_with_null_location,
+        destination=destination_integration_v2_er,
+        provider=connection_v2.provider,
+        route_configuration=None,
+    )
+    assert transformed_observation
+    # Location is set to None when null
+    assert transformed_observation.location is None
+
+
+@pytest.mark.asyncio
 async def test_provider_key_mapping_with_default(
     mock_cache,
     mock_gundi_client_v2,
@@ -290,6 +310,44 @@ async def test_transform_events_for_smart(
     observation_group = attributes.observationGroups[0]
     assert len(observation_group.observations) == 1
     observation = observation_group.observations[0]
+    assert observation.category == "animals.sign"
+    assert observation.attributes == {"ageofsign": "days", "species": "lion"}
+
+
+@pytest.mark.asyncio
+async def test_transform_event_with_null_location_for_smart(
+    mocker,
+    smart_ca_uuid,
+    mock_smart_async_client_class,
+    animals_sign_event_v2_with_null_location,
+    connection_v2,
+    destination_integration_v2_smart,
+):
+    mocker.patch(
+        "app.services.transformers.AsyncSmartClient",
+        mock_smart_async_client_class,
+    )
+    transformed_observation = await transform_observation_v2(
+        observation=animals_sign_event_v2_with_null_location,
+        destination=destination_integration_v2_smart,
+        provider=connection_v2.provider,
+        route_configuration=None,
+    )
+    assert transformed_observation
+    assert transformed_observation.ca_uuid == smart_ca_uuid
+    assert len(transformed_observation.waypoint_requests) == 1
+    waypoint = transformed_observation.waypoint_requests[0]
+    location = waypoint.geometry.coordinates
+    # Location is set to [0, 0] when null
+    assert location == [0, 0]
+    properties = waypoint.properties
+    assert properties
+    assert properties.smartDataType == "incident"
+    assert properties.smartFeatureType == "waypoint/new"
+    attributes = properties.smartAttributes
+    assert attributes
+    assert len(attributes.observationGroups) == 1
+    observation = attributes.observationGroups[0].observations[0]
     assert observation.category == "animals.sign"
     assert observation.attributes == {"ageofsign": "days", "species": "lion"}
 
@@ -659,6 +717,34 @@ async def test_transform_event_for_traptagger(
     assert (
         transformed_observation.timestamp
         == animals_sign_event_v2.recorded_at.strftime("%Y-%m-%d %H:%M:%S")
+    )
+
+
+@pytest.mark.asyncio
+async def test_transform_event_with_null_location_for_traptagger(
+    animals_sign_event_v2_with_null_location,
+    connection_v2_wpswatch_to_traptagger,
+    destination_integration_v2_traptagger,
+):
+    transformed_observation = await transform_observation_v2(
+        observation=animals_sign_event_v2_with_null_location,
+        destination=destination_integration_v2_traptagger,
+        provider=connection_v2_wpswatch_to_traptagger.provider,
+        route_configuration=None,
+    )
+    assert transformed_observation
+    assert isinstance(transformed_observation, schemas.v2.TrapTaggerImageMetadata)
+    assert (
+        transformed_observation.camera
+        == animals_sign_event_v2_with_null_location.external_source_id
+    )
+    assert transformed_observation.latitude == "0.0"
+    assert transformed_observation.longitude == "0.0"
+    assert (
+        transformed_observation.timestamp
+        == animals_sign_event_v2_with_null_location.recorded_at.strftime(
+            "%Y-%m-%d %H:%M:%S"
+        )
     )
 
 


### PR DESCRIPTION
This PR updates transformers for Events sent to ER or Traptagger, to allow routing events without location (lat/lon), which were previously generating errors and being discarded.  Also, test coverage is added accordingly.

Copilot
This pull request introduces improved handling of events with missing location data across several transformers and their associated tests. The main changes ensure that when the location is absent in the input event, each transformer sets the output location field appropriately (either as `None` or a default value), and new tests verify this behavior for EarthRanger, SMART, and TrapTagger integrations.

**Handling of null location in event transformation:**

* Updated the `transform` function in `app/services/transformers.py` to set the output `location` field to `None` if the input event location is missing, and to provide default values (latitude/longitude as `0.0`) for integrations that require numeric coordinates. [[1]](diffhunk://#diff-540d718ca7da47eaf4aedf931fa876ba492a764e9a9bb48f5e56f54fee3bfbb0L1506-R1516) [[2]](diffhunk://#diff-540d718ca7da47eaf4aedf931fa876ba492a764e9a9bb48f5e56f54fee3bfbb0L1663-R1669)

**Test coverage for null location scenarios:**

* Added a new fixture `animals_sign_event_v2_with_null_location` in `app/conftest.py` to generate events with a null location for testing purposes.

* Added tests for EarthRanger, SMART, and TrapTagger integrations in `app/tests/test_transform_observations_v2.py` to ensure that events with a null location are transformed correctly:
  - EarthRanger: Asserts that transformed event location is `None`.
  - SMART: Asserts that transformed waypoint coordinates are `[0, 0]`.
  - TrapTagger: Asserts that latitude and longitude are `"0.0"` strings.