### PR TITLE
Wire INTEGRATION_EVENTS_TOPIC env var into Cloud Run via Terraform

### DIFF
--- a/terraform/modules/cloud-run.tf
+++ b/terraform/modules/cloud-run.tf
@@ -94,6 +94,11 @@ resource "google_cloud_run_v2_service" "default" {
       }
 
       env {
+        name  = "INTEGRATION_EVENTS_TOPIC"
+        value = "integration-events-${var.env}"
+      }
+
+      env {
         name  = "SMART_DEFAULT_TIMEOUT"
         value = var.smart_default_timeout
       }


### PR DESCRIPTION
The activity-log code reads INTEGRATION_EVENTS_TOPIC, but the Terraform module that provisions the Cloud Run service didn't set it — so dev/stage/ prod fell back to the f-string default which uses GCP_ENVIRONMENT, also unset on these services. Production was publishing to integration-events-dev silently. Compute the topic name from var.env to match the naming convention used elsewhere in this module (e.g. transformer-dead-letter-{env}).

IAM is already correct: iam.tf grants roles/pubsub.publisher at the project level, which covers integration-events-{env} without further changes.