### PR TITLE
Select generic-model path by destination type, not a per-integration flag

### DIFF
--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -58,6 +58,16 @@ DEAD_LETTER_TOPIC = env.str("DEAD_LETTER_TOPIC", "transformer-dead-letter-dev")
 MAX_EVENT_AGE_SECONDS = env.int("MAX_EVENT_AGE_SECONDS", 86400)  # 24hrs
 EVENT_PROCESSING_STATUS_TTL = env.int("EVENT_PROCESSING_STATUS_TTL", 3600)
 
+# Destination integration *types* that use the generic-model path: cdip-routing
+# publishes a GundiDelivery envelope and the destination's action runner does
+# the transformation, instead of a legacy in-process Transformer. Keyed by
+# integration type slug so operators never have to set `additional.generic_model`
+# per integration — registering, say, a `cmore` destination is enough. Add a new
+# generic-model destination type here (env override) when it's onboarded.
+GENERIC_MODEL_DESTINATION_TYPES = env.list(
+    "GENERIC_MODEL_DESTINATION_TYPES", ["cmore"]
+)
+
 # Topic for portal-visible activity logs published as gundi_core system events.
 INTEGRATION_EVENTS_TOPIC = env.str(
     "INTEGRATION_EVENTS_TOPIC", f"integration-events-{GCP_ENVIRONMENT}"

--- a/app/services/event_handlers.py
+++ b/app/services/event_handlers.py
@@ -24,7 +24,7 @@ from gundi_core.events.transformers import (
     MessageTransformedInReach,
 )
 from opentelemetry.trace import SpanKind
-from app.core import tracing
+from app.core import settings, tracing
 from app.core.errors import ReferenceDataError
 from app.core.gundi import get_connection, get_route, get_integration
 from app.core.local_logging import ExtraKeys
@@ -41,6 +41,22 @@ from app.services.transformers import (
 
 
 logger = logging.getLogger(__name__)
+
+
+def _uses_generic_model(destination_integration) -> bool:
+    """Whether a destination uses the generic-model path (publish a
+    GundiDelivery for its action runner to transform) instead of a legacy
+    in-process Transformer.
+
+    Decided by the destination's integration *type* (e.g. ``cmore``) via
+    ``settings.GENERIC_MODEL_DESTINATION_TYPES`` so it requires no per-integration
+    config. The legacy per-integration ``additional.generic_model`` flag is still
+    honored as an override for one-off opt-in.
+    """
+    type_value = getattr(getattr(destination_integration, "type", None), "value", None)
+    if type_value and type_value in settings.GENERIC_MODEL_DESTINATION_TYPES:
+        return True
+    return bool((destination_integration.additional or {}).get("generic_model"))
 
 
 transformer_events_by_data_type = {
@@ -223,7 +239,7 @@ async def transform_and_route_observation(observation):
 
                 # Generic-model path: publish a GundiDelivery envelope and let
                 # the action runner perform destination-specific transformation.
-                if (destination_integration.additional or {}).get("generic_model"):
+                if _uses_generic_model(destination_integration):
                     await _publish_gundi_delivery(
                         observation=observation,
                         destination=destination,

--- a/app/tests/test_process_observations_v2_generic.py
+++ b/app/tests/test_process_observations_v2_generic.py
@@ -119,6 +119,42 @@ async def test_legacy_mode_unchanged_when_generic_model_absent(
 
 
 @pytest.mark.asyncio
+async def test_generic_mode_selected_by_destination_type_without_flag(
+    mocker,
+    mock_cache,
+    mock_gundi_client_v2,
+    destination_integration_v2,
+    raw_observation_v2,
+    raw_observation_v2_attributes,
+):
+    """A destination whose *type* is in GENERIC_MODEL_DESTINATION_TYPES uses the
+    generic-model path with no per-integration `additional.generic_model` flag.
+    (Here the ER type is temporarily added to the allow-list to drive it.)"""
+    assert "generic_model" not in (destination_integration_v2.additional or {})
+    mocker.patch(
+        "app.core.settings.GENERIC_MODEL_DESTINATION_TYPES",
+        [destination_integration_v2.type.value],
+    )
+    mock_gundi_client_v2.get_integration_details.return_value = async_return(
+        destination_integration_v2
+    )
+    mocker.patch("app.core.gundi._cache_db", mock_cache)
+    mocker.patch("app.core.gundi.portal_v2", mock_gundi_client_v2)
+    send_mock = mocker.AsyncMock()
+    mocker.patch(
+        "app.services.event_handlers.send_message_to_gcp_pubsub_dispatcher", send_mock
+    )
+    transform_mock = mocker.patch("app.services.event_handlers.transform_observation_v2")
+
+    await process_observation_event(raw_observation_v2, raw_observation_v2_attributes)
+
+    transform_mock.assert_not_called()
+    assert send_mock.call_count == 1
+    payload, _ = _decode_published_payload(send_mock)
+    assert payload["event_type"] == "GundiDelivery"
+
+
+@pytest.mark.asyncio
 async def test_generic_mode_when_additional_is_none(
     mocker,
     mock_cache,


### PR DESCRIPTION
## Problem

cdip-routing chose the generic-model publish path (wrap in `GundiDelivery`, let the action runner transform) from a **per-integration** `additional.generic_model` flag (`event_handlers.py:226`). That makes onboarding a CMORE destination a manual, easy-to-forget portal step — and we can't reasonably ask operators to hand-set an `additional` property on every integration. (Background: GUNDI-5365.)

## Fix

Decide it by the destination integration **type** instead. New setting `GENERIC_MODEL_DESTINATION_TYPES` (env `GENERIC_MODEL_DESTINATION_TYPES`, **default `["cmore"]`**); a destination routes via the generic-model path when its `type.value` is in that set. So registering a `cmore` destination Just Works with zero per-integration config.

The legacy `additional.generic_model` flag is still honored as a per-integration **override** (back-compat + one-off opt-in), via a small `_uses_generic_model()` helper.

Onboarding a new generic-model destination type is now an env-var addition + redeploy (an engineering action when a new runner type ships), not a portal edit on every integration.

## Why type, not instance

"Use the generic-model path" is a property of the destination *type* (its action runner does the transform), not of an individual integration. Legacy destinations (ER, SMART, …) keep using cdip-routing's in-process Transformers; new runner-based types use generic-model.

## Tests

`pytest app/tests/test_process_observations_v2*.py` → **13 passed**, including a new test that a destination routes generic-model **by type with no `additional` flag**. The existing legacy test confirms a non-listed type (ER, default config) still uses the Transformer path; the `additional` override tests still pass.

## Deployment note

This lets us **drop the `additional.generic_model` step** from the production runbook (cdip-routing #150). With the default `["cmore"]`, no env config is even required for CMORE. I'll update the runbook once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)