### PR TITLE
Add PR test gate + share test job with deploy gate; document Python 3.8

### DIFF
--- a/.github/workflows/_tests.yml
+++ b/.github/workflows/_tests.yml
@@ -1,0 +1,32 @@
+name: Run tests
+
+# Reusable test job, called by both the PR workflow (tests.yml) and the
+# build/deploy pipeline (main.yml) so there is a single source of truth for
+# how the suite runs.
+on:
+  workflow_call
+
+jobs:
+  run_unit_tests:
+    runs-on: ubuntu-latest
+    env:
+      # Tests never emit real traces. Disabling avoids the GCP CloudTrace
+      # exporter trying to resolve credentials at import time (configure_tracer
+      # runs on import of app.core.tracing) and failing with
+      # DefaultCredentialsError on a CI runner with no GCP auth.
+      TRACING_ENABLED: "false"
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          # Matches the runtime image (docker/Dockerfile: python:3.8-slim) and
+          # the backports.zoneinfo pin (no wheel for 3.10+). See
+          # docs/python-version.md.
+          python-version: '3.8'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install --no-cache-dir -r requirements.txt
+      - name: Run unit tests
+        run: pytest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,21 +27,10 @@ jobs:
           echo "tag=${tag}" >> $GITHUB_OUTPUT
           echo "repository=us-central1-docker.pkg.dev/cdip-78ca/gundi/cdip-routing" >> $GITHUB_OUTPUT
 
+  # Gates the build/deploy: `build` needs run_unit_tests, so a failing suite
+  # blocks the image. Shares its definition with the PR workflow via _tests.yml.
   run_unit_tests:
-    runs-on: ubuntu-latest
-    needs: [vars]
-    steps:
-      - name: Checkout branch
-        uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.8'
-      - name: Install pip
-        run: python -m ensurepip --upgrade
-      - name: Install dependencies
-        run: pip install -r requirements.txt
-      - name: Run unit tests
-        run: pytest
+    uses: ./.github/workflows/_tests.yml
 
 
   build:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,23 +1,8 @@
-name: Run tests
+name: Tests
 
 on:
   pull_request
 
 jobs:
   run_unit_tests:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout branch
-        uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          # Match the runtime image (docker/Dockerfile is python:3.8-slim).
-          # 3.8 is also required to install the pinned backports.zoneinfo
-          # wheel — it has no wheel for 3.10+ and fails to build there.
-          python-version: '3.8'
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install --no-cache-dir -r requirements.txt
-      - name: Run unit tests
-        run: pytest
+    uses: ./.github/workflows/_tests.yml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,23 @@
+name: Run tests
+
+on:
+  pull_request
+
+jobs:
+  run_unit_tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          # Match the runtime image (docker/Dockerfile is python:3.8-slim).
+          # 3.8 is also required to install the pinned backports.zoneinfo
+          # wheel — it has no wheel for 3.10+ and fails to build there.
+          python-version: '3.8'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install --no-cache-dir -r requirements.txt
+      - name: Run unit tests
+        run: pytest

--- a/docs/python-version.md
+++ b/docs/python-version.md
@@ -1,0 +1,33 @@
+# Python version
+
+## Current state
+
+cdip-routing targets **Python 3.8**:
+- `docker/Dockerfile` → `python:3.8-slim`
+- `requirements.txt` is compiled with `uv pip compile --python-version 3.8`
+- CI (`.github/workflows/_tests.yml`) runs the suite on 3.8 to match
+
+## Why 3.8? (evaluated 2026-06-11)
+
+**It's inertia, not a hard requirement.** The Docker image was set to Python 3.8 in commit `599833e` ("Update docker image for FastAPI", 2024-02-20) and hasn't moved since. Investigation found nothing that actually requires < 3.9:
+
+- No `python_requires` / `requires-python` constraint in `requirements.in`, `setup.py`, or `pyproject.toml`.
+- No code uses `zoneinfo` / `backports.zoneinfo` directly (`grep` across `app/` is empty).
+- `backports-zoneinfo==0.2.1` in the lockfile is a **transitive** dependency that only appears **because the lockfile is compiled for 3.8** — it's gated on `python_version < "3.9"`. It's a *symptom* of the pin, not a reason for it. (It's also the dep that breaks `pip install` on 3.10+, since it has no wheel there and fails to build — which is why CI pins 3.8 today.)
+
+So the 3.8 pin is self-reinforcing: the lockfile targets 3.8 → pulls `backports.zoneinfo` → which only installs on ≤3.8 → so we stay on 3.8.
+
+## Risk
+
+**Python 3.8 reached end-of-life on 2024-10-07** — no security or bug fixes. The sibling Gundi integration runners (gundi-integration-cmore, gundi-integration-earthranger) already run 3.10/3.11.
+
+## Recommendation
+
+Upgrade to **Python 3.11** (aligns with the integration runners) as a focused follow-up:
+
+1. `docker/Dockerfile`: `python:3.11-slim`.
+2. Recompile the lockfile: `uv pip compile --python-version 3.11 -o requirements.txt requirements.in` — this **drops `backports-zoneinfo`** automatically.
+3. Bump `python-version` in `.github/workflows/_tests.yml` to `'3.11'`.
+4. Verify the pinned first-party wheels install on 3.11 (`earthranger_client`, `smartconnect_client` — both appear to be `py3-none-any`, but confirm) and run `pytest`.
+
+Not done here because it's a distinct change with its own validation; tracked as a follow-up. Until then, keep CI on 3.8 so it matches the deployed image.


### PR DESCRIPTION
## What

1. **PR test gate** — `tests.yml` runs the suite on every `pull_request` (cdip-routing previously had no PR test check; PRs only got the GitGuardian scan).
2. **Shared test definition** — extracted a reusable `_tests.yml`. Both the PR workflow and `main.yml`'s `run_unit_tests` now call it, so the **deploy gate and the PR gate use one definition**. (`build` already `needs: run_unit_tests`, so a failing suite blocks the image — that gate already existed on push to main; this just de-duplicates and hardens it.)
3. **Tracing disabled in CI** — `_tests.yml` sets `TRACING_ENABLED=false`. Without it, `configure_tracer` instantiates the GCP CloudTrace exporter at import and fails with `DefaultCredentialsError` on a runner with no GCP auth (this is what made the first attempt red).
4. **`docs/python-version.md`** — evaluates why we're on Python 3.8: it's inertia (set 2024-02, now EOL), not a requirement; `backports.zoneinfo` is a symptom of the 3.8-targeted lockfile. Recommends upgrading to 3.11 as a follow-up. CI stays on 3.8 to match `docker/Dockerfile` until then.

## Validation

The PR triggers `_tests.yml` on itself. Full suite is 84 passed locally on 3.8.